### PR TITLE
Add UnicodeDecodeError on dling skippable errors.

### DIFF
--- a/ricecooker/__init__.py
+++ b/ricecooker/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Learning Equality'
 __email__ = 'jordan@learningequality.org'
-__version__ = '0.3.12'
+__version__ = '0.3.13'

--- a/ricecooker/managers/downloader.py
+++ b/ricecooker/managers/downloader.py
@@ -132,6 +132,9 @@ class DownloadManager:
         except (HTTPError, ConnectionError, InvalidURL, InvalidSchema, IOError):
             self.failed_files += [(path,title)]
             return False;
+        except (HTTPError, FileNotFoundError, ConnectionError, InvalidURL, UnicodeDecodeError, InvalidSchema, IOError):
+            self.failed_files += [(path, title)]
+            return False
 
     def write_to_graphie_file(self, path, tempf, hash):
         """ write_to_graphie_file: write from path to graphie file


### PR DESCRIPTION
This is the error that requests throws on Macs, if you give an invalid URL to requests, not InvalidURL.