### PR TITLE
Fixed validation logic to allow paths without an extension

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -194,8 +194,9 @@ class DownloadFile(File):
 
     def validate(self):
         assert self.path, "{} must have a path".format(self.__class__.__name__)
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert os.path.splitext(self.path)[1][1:] in self.allowed_formats, "{} must have one of the following extensions: {}".format(self.__class__.__name__, self.allowed_formats)
+        _basename, ext = os.path.splitext(self.path)
+        if ext:
+            assert ext.lstrip('.') in self.allowed_formats, "{} must have one of the following extensions: {}".format(self.__class__.__name__, self.allowed_formats)
 
     def process_file(self):
         try:

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -116,7 +116,7 @@ def compress_video_file(filename, ffmpeg_settings):
 
         filename = "{}.{}".format(get_hash(tempf.name), file_formats.MP4)
 
-        copy_file_to_storage(filename, tempf.name, delete_original=True)
+        copy_file_to_storage(filename, tempf.name)
 
         FILECACHE.set(key, bytes(filename, "utf-8"))
         return filename
@@ -269,7 +269,7 @@ class ExtractedVideoThumbnailFile(ThumbnailFile):
             extract_thumbnail_from_video(self.path, tempf.name, overwrite=True)
             filename = "{}.{}".format(get_hash(tempf.name), file_formats.PNG)
 
-            copy_file_to_storage(filename, tempf.name, delete_original=True)
+            copy_file_to_storage(filename, tempf.name)
 
             FILECACHE.set(key, bytes(filename, "utf-8"))
             return filename
@@ -353,7 +353,7 @@ class Base64ImageFile(ThumbnailPresetMixin, File):
             write_base64_to_file(self.encoding, tempf.name)
             filename = "{}.{}".format(get_hash(tempf.name), file_formats.PNG)
 
-            copy_file_to_storage(filename, tempf.name, delete_original=True)
+            copy_file_to_storage(filename, tempf.name)
             FILECACHE.set(key, bytes(filename, "utf-8"))
             return filename
 
@@ -422,7 +422,7 @@ class _ExerciseGraphieFile(DownloadFile):
             tempf.seek(0)
             filename = "{}.{}".format(hash.hexdigest(), file_formats.GRAPHIE)
 
-            copy_file_to_storage(filename, tempf, delete_original=True)
+            copy_file_to_storage(filename, tempf)
 
             FILECACHE.set(key, bytes(filename, "utf-8"))
             return filename

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -207,28 +207,43 @@ class ThumbnailFile(ThumbnailPresetMixin, DownloadFile):
     default_ext = file_formats.PNG
 
     def validate(self):
-        assert os.path.splitext(self.path)[1][1:] in [file_formats.JPG, file_formats.JPEG, file_formats.PNG], "Thumbnails must be in jpg, jpeg, or png format"
+        super(ThumbnailFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert os.path.splitext(self.path)[1][1:] in [file_formats.JPG, file_formats.JPEG, file_formats.PNG], "Thumbnails must be in jpg, jpeg, or png format"
+
 
 class AudioFile(DownloadFile):
+    default_ext = file_formats.MP3
+
     def get_preset(self):
         return self.preset or format_presets.AUDIO
 
     def validate(self):
-        assert self.path.endswith(file_formats.MP3), "Audio files must be in mp3 format"
+        super(AudioFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert self.path.endswith(file_formats.MP3), "Audio files must be in mp3 format"
 
 class DocumentFile(DownloadFile):
+    default_ext = file_formats.PDF
+
     def get_preset(self):
         return self.preset or format_presets.DOCUMENT
 
     def validate(self):
-        assert self.path.endswith(file_formats.PDF), "Document files must be in pdf format"
+        super(DocumentFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert self.path.endswith(file_formats.PDF), "Document files must be in pdf format"
 
 class HTMLZipFile(DownloadFile):
+    default_ext = file_formats.HTML5
+
     def get_preset(self):
         return self.preset or format_presets.HTML5_ZIP
 
     def validate(self):
-        assert self.path.endswith(file_formats.HTML5), "HTML files must be in zip format"
+        super(HTMLZipFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert self.path.endswith(file_formats.HTML5), "HTML files must be in zip format"
         # make sure index.html exists
         with zipfile.ZipFile(self.path) as zf:
             try:
@@ -270,7 +285,9 @@ class VideoFile(DownloadFile):
         return self.preset or guess_video_preset_by_resolution(config.get_storage_path(self.filename))
 
     def validate(self):
-        assert self.path.endswith(file_formats.MP4), "Video files be in mp4 format"
+        super(VideoFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert self.path.endswith(file_formats.MP4), "Video files be in mp4 format"
 
     def process_file(self):
         try:
@@ -287,6 +304,8 @@ class VideoFile(DownloadFile):
 
 
 class SubtitleFile(DownloadFile):
+    default_ext = file_formats.VTT
+
     def __init__(self, path, **kwargs):
         super(SubtitleFile, self).__init__(path, **kwargs)
         assert self.language, "Subtitles must have a language"
@@ -295,17 +314,10 @@ class SubtitleFile(DownloadFile):
         return self.preset or format_presets.VIDEO_SUBTITLE
 
     def validate(self):
-        assert self.path.endswith(file_formats.VTT), "Subtitle files must be in vtt format"
+        super(SubtitleFile, self).validate()
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert self.path.endswith(file_formats.VTT), "Subtitle files must be in vtt format"
 
-
-class _ExerciseImageFile(DownloadFile):
-    default_ext = file_formats.PNG
-
-    def get_replacement_str(self):
-        return self.get_filename() or self.path
-
-    def get_preset(self):
-        return self.preset or format_presets.EXERCISE_IMAGE
 
 class Base64ImageFile(ThumbnailPresetMixin, File):
 
@@ -345,7 +357,6 @@ class Base64ImageFile(ThumbnailPresetMixin, File):
             FILECACHE.set(key, bytes(filename, "utf-8"))
             return filename
 
-
 class _ExerciseBase64ImageFile(Base64ImageFile):
     default_ext = file_formats.PNG
 
@@ -354,6 +365,15 @@ class _ExerciseBase64ImageFile(Base64ImageFile):
 
     def get_replacement_str(self):
         return self.get_filename() or self.encoding
+
+class _ExerciseImageFile(DownloadFile):
+    default_ext = file_formats.PNG
+
+    def get_replacement_str(self):
+        return self.get_filename() or self.path
+
+    def get_preset(self):
+        return self.preset or format_presets.EXERCISE_IMAGE
 
 class _ExerciseGraphieFile(DownloadFile):
     default_ext = file_formats.GRAPHIE

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -187,7 +187,7 @@ class File(object):
 
 class DownloadFile(File):
     def __init__(self, path, **kwargs):
-        self.path = path
+        self.path = path.strip()
         super(DownloadFile, self).__init__(**kwargs)
 
     def validate(self):
@@ -386,7 +386,7 @@ class _ExerciseGraphieFile(DownloadFile):
         return self.preset or format_presets.EXERCISE_GRAPHIE
 
     def get_replacement_str(self):
-        return self.original_filename or self.path
+        return self.path.split("/")[-1].split(".")[0] or self.path
 
     def process_file(self):
         """ download: download a web+graphie file
@@ -414,6 +414,7 @@ class _ExerciseGraphieFile(DownloadFile):
             delimiter = bytes(exercises.GRAPHIE_DELIMITER, 'UTF-8')
             config.LOGGER.info("\tDownloading graphie {}".format(self.original_filename))
 
+
             # Write to graphie file
             hash = write_and_get_hash(self.path + ".svg", tempf)
             tempf.write(delimiter)
@@ -421,6 +422,7 @@ class _ExerciseGraphieFile(DownloadFile):
             hash = write_and_get_hash(self.path + "-data.json", tempf, hash)
             tempf.seek(0)
             filename = "{}.{}".format(hash.hexdigest(), file_formats.GRAPHIE)
+
 
             copy_file_to_storage(filename, tempf)
 

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -186,12 +186,16 @@ class File(object):
         pass
 
 class DownloadFile(File):
+    allowed_formats = []
+
     def __init__(self, path, **kwargs):
         self.path = path.strip()
         super(DownloadFile, self).__init__(**kwargs)
 
     def validate(self):
-        assert self.path, "Download files must have a path"
+        assert self.path, "{} must have a path".format(self.__class__.__name__)
+        if os.path.splitext(self.path)[1][1:] != "":
+            assert os.path.splitext(self.path)[1][1:] in self.allowed_formats, "{} must have one of the following extensions: {}".format(self.__class__.__name__, self.allowed_formats)
 
     def process_file(self):
         try:
@@ -205,45 +209,32 @@ class DownloadFile(File):
 
 class ThumbnailFile(ThumbnailPresetMixin, DownloadFile):
     default_ext = file_formats.PNG
-
-    def validate(self):
-        super(ThumbnailFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert os.path.splitext(self.path)[1][1:] in [file_formats.JPG, file_formats.JPEG, file_formats.PNG], "Thumbnails must be in jpg, jpeg, or png format"
-
+    allowed_formats = [file_formats.JPG, file_formats.JPEG, file_formats.PNG]
 
 class AudioFile(DownloadFile):
     default_ext = file_formats.MP3
+    allowed_formats = [file_formats.MP3]
 
     def get_preset(self):
         return self.preset or format_presets.AUDIO
 
-    def validate(self):
-        super(AudioFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert self.path.endswith(file_formats.MP3), "Audio files must be in mp3 format"
-
 class DocumentFile(DownloadFile):
     default_ext = file_formats.PDF
+    allowed_formats = [file_formats.PDF]
 
     def get_preset(self):
         return self.preset or format_presets.DOCUMENT
 
-    def validate(self):
-        super(DocumentFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert self.path.endswith(file_formats.PDF), "Document files must be in pdf format"
-
 class HTMLZipFile(DownloadFile):
     default_ext = file_formats.HTML5
+    allowed_formats = [file_formats.HTML5]
 
     def get_preset(self):
         return self.preset or format_presets.HTML5_ZIP
 
     def validate(self):
         super(HTMLZipFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert self.path.endswith(file_formats.HTML5), "HTML files must be in zip format"
+
         # make sure index.html exists
         with zipfile.ZipFile(self.path) as zf:
             try:
@@ -276,6 +267,7 @@ class ExtractedVideoThumbnailFile(ThumbnailFile):
 
 class VideoFile(DownloadFile):
     default_ext = file_formats.MP4
+    allowed_formats = [file_formats.MP4]
 
     def __init__(self, path, ffmpeg_settings=None, **kwargs):
         self.ffmpeg_settings = ffmpeg_settings
@@ -283,11 +275,6 @@ class VideoFile(DownloadFile):
 
     def get_preset(self):
         return self.preset or guess_video_preset_by_resolution(config.get_storage_path(self.filename))
-
-    def validate(self):
-        super(VideoFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert self.path.endswith(file_formats.MP4), "Video files be in mp4 format"
 
     def process_file(self):
         try:
@@ -305,6 +292,7 @@ class VideoFile(DownloadFile):
 
 class SubtitleFile(DownloadFile):
     default_ext = file_formats.VTT
+    allowed_formats = [file_formats.VTT]
 
     def __init__(self, path, **kwargs):
         super(SubtitleFile, self).__init__(path, **kwargs)
@@ -312,12 +300,6 @@ class SubtitleFile(DownloadFile):
 
     def get_preset(self):
         return self.preset or format_presets.VIDEO_SUBTITLE
-
-    def validate(self):
-        super(SubtitleFile, self).validate()
-        if os.path.splitext(self.path)[1][1:] != "":
-            assert self.path.endswith(file_formats.VTT), "Subtitle files must be in vtt format"
-
 
 class Base64ImageFile(ThumbnailPresetMixin, File):
 

--- a/ricecooker/sample_program.py
+++ b/ricecooker/sample_program.py
@@ -129,10 +129,8 @@ SAMPLE_TREE = [
                     {
                         "path" : "https://ia801407.us.archive.org/21/items/ah_Rice/Rice.mp3",
                     },
-                    {
-                        "path" : "https://upload.wikimedia.org/wikipedia/commons/b/ba/Rice_grains_(IRRI).jpg",
-                    },
                 ],
+                "thumbnail": "https://upload.wikimedia.org/wikipedia/commons/b/ba/Rice_grains_(IRRI)",
                 "description": "Get online updates regarding world's leading long grain rice distributors, broken rice distributors, rice suppliers, parboiled rice exporter on our online B2B marketplace TradeBanq.",
                 "license": licenses.PUBLIC_DOMAIN,
             },
@@ -334,6 +332,7 @@ def _build_tree(node, sourcetree):
                 title=child_source_node["title"],
                 author=child_source_node.get("author"),
                 description=child_source_node.get("description"),
+                thumbnail=child_source_node.get("thumbnail"),
             )
             node.add_child(child_node)
 
@@ -349,6 +348,7 @@ def _build_tree(node, sourcetree):
                 description=child_source_node.get("description"),
                 license=child_source_node.get("license"),
                 derive_thumbnail=True, # video-specific data
+                thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])
             node.add_child(child_node)
@@ -360,6 +360,7 @@ def _build_tree(node, sourcetree):
                 author=child_source_node.get("author"),
                 description=child_source_node.get("description"),
                 license=child_source_node.get("license"),
+                thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])
             node.add_child(child_node)
@@ -371,6 +372,7 @@ def _build_tree(node, sourcetree):
                 author=child_source_node.get("author"),
                 description=child_source_node.get("description"),
                 license=child_source_node.get("license"),
+                thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])
             node.add_child(child_node)
@@ -383,6 +385,7 @@ def _build_tree(node, sourcetree):
                 description=child_source_node.get("description"),
                 exercise_data={}, # Just set to default
                 license=child_source_node.get("license"),
+                thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])
             for q in child_source_node.get("questions"):
@@ -397,6 +400,7 @@ def _build_tree(node, sourcetree):
                 author=child_source_node.get("author"),
                 description=child_source_node.get("description"),
                 license=child_source_node.get("license"),
+                thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])
             node.add_child(child_node)

--- a/ricecooker/sample_program.py
+++ b/ricecooker/sample_program.py
@@ -82,7 +82,17 @@ SAMPLE_PERSEUS = '{"answerArea":{"chi2Table":false,"periodicTable":false,"tTable
 '"question":{"widgets":{"radio 1":{"type":"radio","alignment":"default","graded":true,"static":false,' +\
 '"options":{"deselectEnabled":false,"multipleSelect":false,"choices":[{"correct":true,"content":"Yes"},{"correct":false,"content":"No"}],' +\
 '"displayCount":null,"hasNoneOfTheAbove":false,"randomize":false,"onePerLine":true},"version":{"minor":0,"major":1}}},"images":{"web+graphie:C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5": {}},' +\
-'"content":"Do you like rice?\\\"\\n\\n![](web+graphie:C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5)\\n\\n[[\\u2603 radio 1]]"},"itemDataVersion":{"minor":1,"major":0}}'
+'"content":"Do you like rice?\\\"\\n\\n![](web+graphie:file:///C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5)\\n\\n[[\\u2603 radio 1]]"},"itemDataVersion":{"minor":1,"major":0}}'
+
+SAMPLE_PERSEUS_2 = '{"hints":[{"replace":false,"content":"Numbers are equivalent when they are located at the same point on the number line.\\n\\nLet\'s ' +\
+'see what fraction is at the same location as $\\\\tealD{\\\\dfrac48}$ on the number line.\\n","widgets":{},"images":{"web+graphie:file:///C:/Users/Jordan/contentcuration-dump/ddb3feb4c8e3740ca4f10c2ebad70b5797f60ebd":' +\
+'{"width":460,"height":120}}},{"replace":false,"content":"![](web+graphie:file:///home/ralphie/Desktop/ka-sushi-chef-sw/build/a61/a61ac6f4038cb3e2c3bd6e69f6e75da10632a3d4\\n)\\n\\n $\\\\purpleC{\\\\dfrac24}$ is at the same location on the ' +\
+'number line as  $\\\\tealD{\\\\dfrac48}$.\\n","widgets":{},"images":{}},{"replace":false,"content":" $\\\\purpleC{\\\\dfrac24}$ is equivalent to $\\\\tealD{\\\\dfrac48}$.\\n\\n![]( web+graphie:file:///home/ralphie/Desktop/ka-sushi-chef-sw/' +\
+'build/e84/e84b6d5fa1410f002ef8f9446a999d4a09266edd)","widgets":{},"images":{"web+graphie:file:///home/ralphie/Desktop/ka-sushi-chef-sw/build/6a1/6a1bf04c8df3d217c846362e8902008d84d10ff4":{"width":460,"height":120}}}],"question":{"content"' +\
+':"![](web+graphie:file:///home/ralphie/Desktop/ka-sushi-chef-sw/build/749/749d2d16db0cfc94e8685f3eb7302394448d8c8c)\\n\\n**Move the dot to a fraction equivalent to $\\\\tealD{\\\\dfrac48}$ on the number line.**\\n\\n\\n[[\\u2603 number-line ' +\
+'1]]\\n","widgets":{"number-line 1":{"type":"number-line","static":false,"options":{"initialX":null,"labelRange":[null,null],"divisionRange":[null,null],"correctX":0.5,"labelStyle":"non-reduced","labelTicks":true,"snapDivisions":2,"correctRel":' +\
+'"eq","static":false,"numDivisions":null,"range":[null,null],"tickStep":0.25},"graded":true,"version":{"minor":0,"major":0},"alignment":"default"}},"images":{}},"itemDataVersion":{"minor":1,"major":0},"answerArea":{"periodicTable":false,"zTable":' +\
+'false,"chi2Table":false,"calculator":false,"tTable":false}}'
 
 SAMPLE_TREE = [
     {
@@ -93,18 +103,18 @@ SAMPLE_TREE = [
         "license": licenses.CC_BY_NC_SA,
         "files": [
             {
-                "path": "C:/Users/Jordan/Videos/testfolder/high resolution.mp4",
+                "path": "file:///C:/Users/Jordan/Videos/testfolder/high resolution.mp4",
                 # "ffmpeg_settings": {"max_width": 480, "crf": 20},
             },
-            {
-                "path": "C:/users/jordan/Videos/testfolder/captions.vtt",
-                "language": languages.getlang('en').code,
-            }
-            ,
-            {
-                "path": "file:///C:/users/jordan/Videos/testfolder/captions.vtt",
-                "language": languages.getlang('es').code,
-            }
+            # {
+            #     "path": "C:/users/jordan/Videos/testfolder/captions.vtt",
+            #     "language": languages.getlang('en').code,
+            # }
+            # ,
+            # {
+            #     "path": "file:///C:/users/jordan/Videos/testfolder/captions.vtt",
+            #     "language": languages.getlang('es').code,
+            # }
         ],
     },
     {
@@ -195,12 +205,16 @@ SAMPLE_TREE = [
                         "question": "Which rice is the crunchiest?",
                         "type":exercises.SINGLE_SELECTION,
                         "correct_answer": "Rice Krispies \n![](https://upload.wikimedia.org/wikipedia/commons/c/cd/RKTsquares.jpg)",
-                        "all_answers": ["White rice \n![](https://upload.wikimedia.org/wikipedia/commons/4/4b/Thai_jasmine_rice_uncooked.jpg)", "Brown rice \n![](https://c2.staticflickr.com/4/3159/2889140143_b99fd8dd4c_z.jpg?zz=1)", "Rice Krispies \n![](https://upload.wikimedia.org/wikipedia/commons/c/cd/RKTsquares.jpg)"],
+                        "all_answers": [
+                            "White rice \n![](web+graphie:file:///C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5)![](web+graphie:file:///C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5 - Copy)![](web+graphie:file:///C:/users/jordan/contentcuration-dump/0a0c0f1a1a40226d8d227a07dd143f8c08a4b8a5)",
+                            "Brown rice \n![](https://c2.staticflickr.com/4/3159/2889140143_b99fd8dd4c_z.jpg?zz=1)",
+                            "Rice Krispies \n![](https://upload.wikimedia.org/wikipedia/commons/c/cd/RKTsquares.jpg)"
+                        ],
                         "hints": "It's delicious",
                     },
                     {
                         "id": "ccccc",
-                        "question": "Why a rice cooker?",
+                        "question": "Why a rice cooker? ![bb8](https://media.giphy.com/media/9fbYYzdf6BbQA/giphy.gif)",
                         "type":exercises.FREE_RESPONSE,
                         "answers": [],
                         "images": None,
@@ -215,7 +229,7 @@ SAMPLE_TREE = [
                     {
                         "id": "ddddd",
                         "type":exercises.PERSEUS_QUESTION,
-                        "item_data":SAMPLE_PERSEUS,
+                        "item_data":SAMPLE_PERSEUS_2,
                     },
                 ],
             },

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "requests>=2.11.1",
     "pillow>=3.3.1",
     "docopt>=0.6.2",
-    "le_utils==0.0.9rc14",
+    "le_utils==0.0.9rc18",
     "validators",
     "requests_file",
     "beautifulsoup4==4.5.1",


### PR DESCRIPTION
Ricecooker will use a default_ext if the path doesn't end with one. However, validation requires it to have an extension. This PR fixes that