### PR TITLE
Documenting dependency on css-html-js-minify

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requirements = [
     "html5lib",
     "cachecontrol==0.12.0",
     "lockfile==0.12.2",
+    "css-html-js-minify==2.2.2",
 ]
 
 test_requirements = [


### PR DESCRIPTION
The latest `ricecooker==0.4.7` uses `css-html-js-minify` package, so adding it to deps in `setup.py`.
