### PR TITLE
Fail loudly if called by Python 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: a11d9314b22d8f8c7556443875b731ef05965464
+    hooks:
+    -   id: trailing-whitespace
+    -   id: flake8
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+-   repo: git://github.com/FalconSocial/pre-commit-python-sorter
+    sha: 5991d2aea26858d3c3538e0b4e09255b6b99413e
+    hooks:
+    -   id: python-import-sorter
+        args:
+        - --silent-overwrite
+-   repo: git://github.com/pre-commit/mirrors-eslint
+    sha: v3.14.0
+    hooks:
+    -   id: eslint
+        additional_dependencies: [ 'eslint', 'eslint-plugin-html', 'eslint-config-airbnb', 'eslint-plugin-import', 'eslint-plugin-jsx-a11y']

--- a/ricecooker/__init__.py
+++ b/ricecooker/__init__.py
@@ -3,3 +3,8 @@
 __author__ = 'Learning Equality'
 __email__ = 'jordan@learningequality.org'
 __version__ = '0.5.13'
+
+import sys
+
+if sys.version_info < (3, 4, 0):
+    raise RuntimeError("Ricecooker only supports Python 3.4+")


### PR DESCRIPTION
Fixes #93 

Also copied in the pre-commit hooks from Kolibri.

To use them, run:

```
pip install pre-commit
pre-commit install
```