### PR TITLE
SushiBar support for https:// and wss://

### DIFF
--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -71,8 +71,8 @@ DOWNLOAD_SESSION.mount('file://', FileAdapter())
 
 # Sushi bar server
 SUSHI_BAR_DOMAIN = os.getenv('SUSHI_BAR_URL', "127.0.0.1:8000")
-SUSHI_BAR_HTTP = 'http://' + SUSHI_BAR_DOMAIN
-SUSHI_BAR_WEBSOCKET = 'ws://' + SUSHI_BAR_DOMAIN
+SUSHI_BAR_HTTP = 'https://' + SUSHI_BAR_DOMAIN
+SUSHI_BAR_WEBSOCKET = 'wss://' + SUSHI_BAR_DOMAIN
 SUSHI_BAR_CHANNEL_URL = "{domain}/api/channels/"
 SUSHI_BAR_CHANNEL_RUNS_URL = "{domain}/api/channelruns/"
 SUSHI_BAR_CHANNEL_RUNS_DETAIL_URL = "{domain}/api/channelruns/{run_id}/"


### PR DESCRIPTION
The old sushibar was: http://leq.sidewayspass.com/

The new sushibar is https://sushibar.learningequality.org/

This PR makes two small change to it chefs use SSL when reporing to the new bar, so that we can use this to run chefs with reporing:

```
export SUSHI_BAR_URL="sushibar.learningequality.org"
./mychef.py -v --token=... 
```
