### PR TITLE
Simplified examples; rely on BaseChef.get_channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,12 @@ class MySushiChef(SushiChef):
     }
 
     def construct_channel(self, **kwargs):
-        channel_info = self.channel_info
         # create channel
-        channel = ChannelNode(
-            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],
-            source_id = channel_info['CHANNEL_SOURCE_ID'],
-            title = channel_info['CHANNEL_TITLE'],
-            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
-            description = channel_info.get('CHANNEL_DESCRIPTION'),
-       )
-       # create a topic and add it to channel
-       potato_topic = TopicNode(source_id="<potatos_id>", title="Potatoes!")
-       channel.add_child(potato_topic)
-       return channel
+        channel = self.get_channel(**kwargs)
+        # create a topic and add it to channel
+        potato_topic = TopicNode(source_id="<potatos_id>", title="Potatoes!")
+        channel.add_child(potato_topic)
+        return channel
 
 ```
 

--- a/docs/tutorial/quickstart.ipynb
+++ b/docs/tutorial/quickstart.ipynb
@@ -29,7 +29,7 @@
     "   - `channel_info` (dict) provides channel info\n",
     "\n",
     "   - `construct_channel(**kwargs) -> ChannelNode`: This method is responsible for\n",
-    "      building the structure of your channel (to be discussed below).\n",
+    "      creating the channel and building the tree structure (to be discussed below).\n",
     "\n",
     "\n",
     "\n",
@@ -40,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ricecooker.chefs import SushiChef\n",
@@ -59,20 +61,12 @@
     "    }\n",
     "\n",
     "    def construct_channel(self, **kwargs):\n",
-    "        channel_info = self.channel_info\n",
     "        # create channel\n",
-    "        channel = ChannelNode(\n",
-    "            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],\n",
-    "            source_id = channel_info['CHANNEL_SOURCE_ID'],\n",
-    "            title = channel_info['CHANNEL_TITLE'],\n",
-    "            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),\n",
-    "            description = channel_info.get('CHANNEL_DESCRIPTION'),\n",
-    "        )\n",
+    "        channel = self.get_channel(**kwargs)\n",
     "        # create a topic and add it to channel\n",
     "        potato_topic = TopicNode(source_id=\"<potatos_id>\", title=\"Potatoes!\")\n",
     "        channel.add_child(potato_topic)\n",
-    "        return channel\n",
-    "\n"
+    "        return channel\n"
    ]
   },
   {
@@ -223,7 +217,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },

--- a/examples/large_wikipedia_chef.py
+++ b/examples/large_wikipedia_chef.py
@@ -54,7 +54,6 @@ def get_parsed_html_from_url(url, *args, **kwargs):
 class LargeWikipediaChef(SushiChef):
     """
     The chef class that takes care of uploading channel to the content curation server.
-
     We'll call its `main()` method from the command line script.
     """
     channel_info = {    #
@@ -69,14 +68,7 @@ class LargeWikipediaChef(SushiChef):
         """
         Create ChannelNode and build topic tree.
         """
-        channel_info = self.channel_info
-        channel = ChannelNode(
-            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],
-            source_id = channel_info['CHANNEL_SOURCE_ID'],
-            title = channel_info['CHANNEL_TITLE'],
-            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
-            description = channel_info.get('CHANNEL_DESCRIPTION'),
-        )
+        channel = self.get_channel(*args, **kwargs)  # creates ChannelNode from data in self.channel_info
         city_topic = TopicNode(source_id="List_of_largest_cities", title="Cities!")
         channel.add_child(city_topic)
         add_subpages_from_wikipedia_list(city_topic, "https://en.wikipedia.org/wiki/List_of_largest_cities")

--- a/examples/sample_program.py
+++ b/examples/sample_program.py
@@ -301,14 +301,7 @@ class SampleChef(SushiChef):
         """
         Create ChannelNode and build topic tree.
         """
-        channel_info = self.channel_info
-        channel = nodes.ChannelNode(
-            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],
-            source_id = channel_info['CHANNEL_SOURCE_ID'],
-            title = channel_info['CHANNEL_TITLE'],
-            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
-            description = channel_info.get('CHANNEL_DESCRIPTION'),
-        )
+        channel = self.get_channel(*args, **kwargs)   # creates ChannelNode from data in self.channel_info
         _build_tree(channel, SAMPLE_TREE)
         raise_for_invalid_channel(channel)
 

--- a/examples/tutorial_chef.py
+++ b/examples/tutorial_chef.py
@@ -32,14 +32,7 @@ class TutorialChef(SushiChef):
         """
         # Create channel
         ########################################################################
-        channel_info = self.channel_info
-        channel = ChannelNode(
-            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],
-            source_id = channel_info['CHANNEL_SOURCE_ID'],
-            title = channel_info['CHANNEL_TITLE'],
-            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
-            description = channel_info.get('CHANNEL_DESCRIPTION'),
-        )
+        channel = self.get_channel(*args, **kwargs)     # uses self.channel_info
 
         # Create topics to add to your channel
         ########################################################################


### PR DESCRIPTION
This PR changes all the examples to use `self.get_channel` instead of manually copying over the data from `self.channel_info`. It's a bit more "magical" but reduces the boilerplate so better overall.

The chef in `examples/wikipedia_chef.py` implements its own `get_channel` method—all it has to do is return a ChannelNode.

Related doc on updating chefs:
https://docs.google.com/document/d/1Hs0wQxYcc5dBO6EMSDoQ7-DBj9WfIj3HnX9kUo8XU2k/edit?usp=sharing