### PR TITLE
Update pressurecooker requirement to 0.0.15 to fix issue #105

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "validators",
     "requests_file",
     "beautifulsoup4==4.5.1",
-    "pressurecooker==0.0.11",
+    "pressurecooker==0.0.15",
     "selenium==3.0.1",
     "youtube-dl",
     "html5lib",


### PR DESCRIPTION
See #105 for an unhandled exception when supplying ricecooker with a corrupt mp4 video file. The issue is fixed by updating to latest pressurecooker.
