### PR TITLE
Fully close selenium webdriver's spawned processes

### DIFF
--- a/ricecooker/utils/html.py
+++ b/ricecooker/utils/html.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import signal
 import time
 import urllib
 
@@ -38,7 +39,11 @@ class WebDriver(object):
         return self.driver
 
     def __exit__(self ,type, value, traceback):
-        self.driver.close()
+        # driver.quit() by itself doesn't suffice to fully terminate spawned
+        # PhantomJS processes:
+        # see https://github.com/seleniumhq/selenium/issues/767
+        self.driver.service.process.send_signal(signal.SIGTERM)
+        self.driver.quit()
 
 
 def get_generated_html_from_driver(driver, tagname="html"):


### PR DESCRIPTION
Previously, after each run of the Open Osmosis sushi chef, there would be remaining `phantomjs` processes still running, which would clog up the network bandwidth quite a bit. Apparently calling `driver.close()` doesn't suffice to fully close out all spawned processes of PhantomJS, as documented in https://github.com/seleniumhq/selenium/issues/767 . This fixes that.

Tested by running the Open Osmosis sushi chef pointing to the local checkout of Ricecooker with these changes (`pip install -e /path/to/local/ricecooker/`) and ensuring there are no `phantomjs` processes left over after the run (whereas there were before this change).