### PR TITLE
Use unicodedata.normalize to ensure consistent unicode keys

### DIFF
--- a/ricecooker/utils/data_writer.py
+++ b/ricecooker/utils/data_writer.py
@@ -171,6 +171,7 @@ class DataWriter():
         self._parse_path(path)
         if not ext:
             _name, ext = os.path.splitext(download_url or "")
+            ext = ext.lower()  # normalize to lowercase extensions inside zip archive
         filepath = "{}/{}{}".format(path, title, ext)
         if download_url and filepath:
             self._write_to_zip(filepath, read(download_url))

--- a/ricecooker/utils/metadata_provider.py
+++ b/ricecooker/utils/metadata_provider.py
@@ -1,5 +1,6 @@
 import csv
 import os
+from unicodedata import normalize
 
 from ricecooker.config import LOGGER
 
@@ -54,12 +55,16 @@ CONTENT_INFO_HEADER = [
 
 def path_to_tuple(path, windows=False):
     """
-    Used to split a `chan_path`
+    Split `chan_path` into individual parts and form a tuple (used as key).
     """
     if windows:
         path_tup = tuple(path.split('\\'))
     else:
         path_tup = tuple(path.split('/'))
+    #
+    # Normalize UTF-8 encoding to consistent form so cache lookups will work, see
+    # https://docs.python.org/3.6/library/unicodedata.html#unicodedata.normalize
+    path_tup = tuple(normalize('NFD', part) for part in path_tup)
     return path_tup
 
 def get_metadata_file_path(channeldir, filename):
@@ -244,10 +249,10 @@ class CsvMetadataProvider(MetadataProvider):
                 thumbnail_path_tuples.append(thumbnail_path_tuple)
         # channel thumbnail
         channel_info = self.get_channel_info()
-        thumbnail_path = channel_info.get('thumbnail_chan_path', None)
-        if thumbnail_path:
-            thumbnail_path_tuple = path_to_tuple(thumbnail_path, windows=self.winpaths)
-            thumbnail_path_tuples.append(thumbnail_path_tuple)
+        chthumbnail_path = channel_info.get('thumbnail_chan_path', None)
+        if chthumbnail_path:
+            chthumbnail_path_tuple = path_to_tuple(chthumbnail_path, windows=self.winpaths)
+            thumbnail_path_tuples.append(chthumbnail_path_tuple)
         return thumbnail_path_tuples
 
 


### PR DESCRIPTION
This is a workaround for the following stagnge utf8 inconsisent encoding (unicode of path in .csv vs unicode of filesystem differ)

```
In [11]: key
Out[11]: ('Sample Souschef Channel (Wikipedia)', 'Citrus!', 'Cam sành.jpg')

In [12]: q
Out[12]: ('Sample Souschef Channel (Wikipedia)', 'Citrus!', 'Cam sành.jpg')
```


query q looks the same as key but the match fails...


indeed seems to be encoded differently:



```
In [19]: def print_bytes(tu):
    ...:     print(tu[0].encode('utf-8'), tu[1].encode('utf-8'), tu[2].encode('utf-8') )

In [20]: print_bytes(key)
b'Sample Souschef Channel (Wikipedia)' b'Citrus!' b'Cam s\xc3\xa0nh.jpg'

In [21]: print_bytes(q)
b'Sample Souschef Channel (Wikipedia)' b'Citrus!' b'Cam sa\xcc\x80nh.jpg'
```
