### PR TITLE
Fix problem of svg files not being downloaded due to missing protocol

### DIFF
--- a/ricecooker/classes/questions.py
+++ b/ricecooker/classes/questions.py
@@ -170,7 +170,7 @@ class BaseQuestion:
         # If it is a web+graphie, download svg and json files,
         # Otherwise, download like other files
         if graphie_match:
-            path_text = graphie_match.group().replace("web+graphie:", "")
+            path_text = graphie_match.group().replace("web+graphie:", "http:")
             exercise_file = _ExerciseGraphieFile(path_text)
         elif get_base64_encoding(text):
             exercise_file = _ExerciseBase64ImageFile(path_text)


### PR DESCRIPTION
Graphie files wouldn't be properly generated because it would try to download from url like `//ka-perseus-graphie.s3.amazonaws.com/883480314c702c447570bcee34b2b435d3149ebf.svg` instead of `http://ka-perseus-graphie.s3.amazonaws.com/883480314c702c447570bcee34b2b435d3149ebf.svg`