### PR TITLE
Bugfix for non-git chef runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rice Cooker
 
-A framework for creating channels on [Kolibri Studio](https://contentworkshop.learningequality.org/).
+A framework for creating channels on [Kolibri Studio](https://studio.learningequality.org/).
 
 
 ## Installation
@@ -25,7 +25,7 @@ A sample sushi chef has been created [here](https://github.com/learningequality/
 ### Step 1: Obtaining an Authorization Token ###
 You will need an authorization token to create a channel on Kolibri Studio. In order to obtain one:
 
-1. Create an account on [Kolibri Studio](https://contentworkshop.learningequality.org/).
+1. Create an account on [Kolibri Studio](https://studio.learningequality.org/).
 2. Navigate to the Tokens tab under your Settings page.
 3. Copy the given authorization token.
 4. Set `token="auth-token"` in your call to uploadchannel (alternatively, you can create a file with your

--- a/docs/tutorial/languages.ipynb
+++ b/docs/tutorial/languages.ipynb
@@ -365,7 +365,7 @@
      "text": [
       "\n",
       "\n",
-      "DONE: Channel created at https://contentworkshop.learningequality.org/channels/cba91822d3ab5a748cd19532661d690f/edit\n",
+      "DONE: Channel created at https://studio.learningequality.org/channels/cba91822d3ab5a748cd19532661d690f/edit\n",
       "\n"
      ]
     }
@@ -660,7 +660,7 @@
       "Upload time: 2.453117s\n",
       "\n",
       "\n",
-      "DONE: Channel created at https://contentworkshop.learningequality.org/channels/94cae9e3b077507eaf642602c9059e70/edit\n",
+      "DONE: Channel created at https://studio.learningequality.org/channels/94cae9e3b077507eaf642602c9059e70/edit\n",
       "\n"
      ]
     }

--- a/docs/tutorial/quickstart.ipynb
+++ b/docs/tutorial/quickstart.ipynb
@@ -196,7 +196,7 @@
       "Upload time: 1.279542s\n",
       "\n",
       "\n",
-      "DONE: Channel created at https://contentworkshop.learningequality.org/channels/5c2e522d86fa56818fb20c49e51d9398/edit\n",
+      "DONE: Channel created at https://studio.learningequality.org/channels/5c2e522d86fa56818fb20c49e51d9398/edit\n",
       "\n"
      ]
     }

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -104,10 +104,10 @@ def uploadchannel(chef, update=False, thumbnails=False, download_attempts=3, res
     username, token = authenticate_user(token)
     check_version_number()
 
-    # Set dashboard client settings
+    # Setup Sushibar client based on channel info in `get_channel`
     config.LOGGER.info("Running get_channel... ")
     channel = chef.get_channel(**kwargs)
-    config.SUSHI_BAR_CLIENT = SushiBarClient(channel, username, token)
+    config.SUSHI_BAR_CLIENT = SushiBarClient(channel, username, token, nomonitor=kwargs['nomonitor'])
 
     config.LOGGER.info("\n\n***** Starting channel build process *****\n\n")
 

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -15,8 +15,11 @@ SUSHI_BAR_CLIENT = None
 STAGE = False
 LOGGER = logging.getLogger()
 
-# Domain and file store location for uploading to production server
-DOMAIN = os.getenv('CONTENTWORKSHOP_URL', "https://contentworkshop.learningequality.org")
+# Domain and file store location for uploading to production Studio server
+DOMAIN_ENV = os.getenv('STUDIO_URL', None)
+if DOMAIN_ENV is None:  # check old ENV varable for backward compatibility
+    DOMAIN_ENV = os.getenv('CONTENTWORKSHOP_URL', None)
+DOMAIN = DOMAIN_ENV if DOMAIN_ENV else "https://studio.learningequality.org"
 if DOMAIN.endswith('/'):
     DOMAIN = DOMAIN.rstrip('/')
 FILE_STORE_LOCATION =  hashlib.md5(DOMAIN.encode('utf-8')).hexdigest()

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger()
 DOMAIN_ENV = os.getenv('STUDIO_URL', None)
 if DOMAIN_ENV is None:  # check old ENV varable for backward compatibility
     DOMAIN_ENV = os.getenv('CONTENTWORKSHOP_URL', None)
-DOMAIN = DOMAIN_ENV if DOMAIN_ENV else "https://studio.learningequality.org"
+DOMAIN = DOMAIN_ENV if DOMAIN_ENV else "https://contentworkshop.learningequality.org"
 if DOMAIN.endswith('/'):
     DOMAIN = DOMAIN.rstrip('/')
 FILE_STORE_LOCATION =  hashlib.md5(DOMAIN.encode('utf-8')).hexdigest()

--- a/ricecooker/sushi_bar_client.py
+++ b/ricecooker/sushi_bar_client.py
@@ -81,9 +81,9 @@ class ReconnectingWebSocket(threading.Thread):
 class SushiBarClient(object):
     """Sends events/logs to the dashboard server."""
 
-    def __init__(self, channel, username, token):
+    def __init__(self, channel, username, token, nomonitor=False):
         self.run_id = None
-        if not channel:
+        if nomonitor or not channel:
             return
         if self.__create_channel_if_needed(channel, username, token):
             self.run_id = self.__create_channel_run(channel, username, token)


### PR DESCRIPTION
In this PR:
  - fix for https://github.com/learningequality/ricecooker/issues/134
  - Rename contentcuration URLs to studio URLs
     - Add support for new environment variable STUDIO_URL (in preparation for upcoming docs update)
  - Enabled `--nomonitor` command line argument (if you want to do a chef run that doesn't talk to sushibar, e.g. for testing purposes etc.)

