### PR TITLE
Improve downloader.read with retry logic and (hopefully) reduced JS waiting

### DIFF
--- a/ricecooker/utils/downloader.py
+++ b/ricecooker/utils/downloader.py
@@ -16,14 +16,17 @@ DOWNLOAD_SESSION.mount('http://', forever_adapter)
 DOWNLOAD_SESSION.mount('https://', forever_adapter)
 
 
-def read(path, loadjs=False, session=None, driver=None, loadjs_wait_time=3,
-        loadjs_wait_for_callback=None):
+def read(path, loadjs=False, session=None, driver=None, timeout=60,
+        clear_cookies=True, loadjs_wait_time=3, loadjs_wait_for_callback=None):
     """ read: Reads from source and returns contents
         Args:
             path: (str) url or local path to download
             loadjs: (boolean) indicates whether to load js (optional)
             session: (requests.Session) session to use to download (optional)
             driver: (selenium.webdriver) webdriver to use to download (optional)
+            timeout: (int) Maximum number of seconds to wait for the request to
+                complete.
+            clear_cookies: (boolean) whether to clear cookies.
             loadjs_wait_time: (int) if loading JS, seconds to wait after the
                 page has loaded before grabbing the page source
             loadjs_wait_for_callback: (function<selenium.webdriver>) if loading
@@ -32,9 +35,15 @@ def read(path, loadjs=False, session=None, driver=None, loadjs_wait_time=3,
                 webdriver, and should return True when we're ready to grab the
                 page source. For example, pass in an argument like:
                     lambda driver: driver.find_element_by_id('list-container')
+                to wait for the #list-container element to be present before
+                rendering.
         Returns: str content from file or page
     """
     session = session or DOWNLOAD_SESSION
+
+    if clear_cookies:
+        session.cookies.clear()
+
     try:
         if loadjs:                                              # Wait until js loads then return contents
             if PHANTOMJS_PATH:
@@ -46,10 +55,25 @@ def read(path, loadjs=False, session=None, driver=None, loadjs_wait_time=3,
                 selenium_ui.WebDriverWait(driver, 60).until(loadjs_wait_for_callback)
             time.sleep(loadjs_wait_time)
             return driver.page_source
+
         else:                                                   # Read page contents from url
-            response = DOWNLOAD_SESSION.get(path, stream=True)
+            retry_count = 0
+            max_retries = 5
+            while True:
+                try:
+                    response = DOWNLOAD_SESSION.get(path, stream=True, timeout=timeout)
+                    break
+                except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout) as e:
+                    retry_count += 1
+                    print("Error with connection ('{msg}'); about to perform retry {count} of {trymax}."
+                        .format(msg=str(e), count=retry_count, trymax=max_retries))
+                    time.sleep(retry_count * 1)
+                    if retry_count >= max_retries:
+                        raise e
+
             response.raise_for_status()
             return response.content
+
     except (requests.exceptions.MissingSchema, requests.exceptions.InvalidSchema):
         with open(path, 'rb') as fobj:                          # If path is a local file path, try to open the file
             return fobj.read()


### PR DESCRIPTION
(Review is not urgent)

1. For the non-loading-JS case, add some retry-and-wait logic, copied from previous chefs.
2. For the load-JS case, parameterize the wait time and change its default from 5 to 3 seconds, since [Selenium Phantom JS already waits for the page to load](https://stackoverflow.com/questions/26566799/how-to-wait-until-the-page-is-loaded-with-selenium-for-python/26567563#26567563) in the call to `driver.get()`. (So the wait time would just be time for the JS to execute and make any changes to the page before we grab its source.) Also, added a callback parameter to more dynamically tell us when we can grab the page source.

Test plan:

1. 

```
import ricecooker.utils.downloader as downloader

source = downloader.read(
    "http://3asafeer.com/",
    loadjs=False,
)
print('Page source is:', source)
```

2.

```
import ricecooker.utils.downloader as downloader

source = downloader.read(
    "http://3asafeer.com/",
    loadjs=True,
    loadjs_wait_time=1,
    loadjs_wait_for_callback=lambda driver: driver.find_element_by_id('readLink')
)
print('Page source is:', source)
```
