### PR TITLE
Remove `css_html_js_minify` to get Python3.4 compatibility

### DIFF
--- a/ricecooker/utils/html.py
+++ b/ricecooker/utils/html.py
@@ -5,7 +5,6 @@ import time
 import urllib
 
 from bs4 import BeautifulSoup
-from css_html_js_minify.minify import process_multiple_files, walk2list, Pool, cpu_count, partial
 from selenium import webdriver
 from urllib.parse import urlparse, unquote
 
@@ -128,27 +127,3 @@ def download_file(url, destpath, filename=None, baseurl=None, subpath=None, midd
         f.write(content)
 
     return relative_file_url, response
-
-import logging
-
-def minimize_html_css_js(directory, blacklist=None):
-
-    original_log_level = logging.getLogger().getLevel()
-    logging.getLogger().setLevel(logging.ERROR)
-
-    blacklist = tuple(blacklist or []) + (".min.css", ".min.js")
-
-    list_of_files = walk2list(directory, (".css", ".js", ".html"), blacklist)
-
-    pool = Pool(cpu_count())  # Multiprocessing Async
-    pool.map_async(partial(
-            process_multiple_files, watch=False,
-            wrap=False, timestamp=False,
-            comments=False, sort=True,
-            overwrite=True, zipy=False,
-            prefix="", add_hash=False),
-        list_of_files)
-    pool.close()
-    pool.join()
-
-    logging.getLogger().setLevel(original_log_level)


### PR DESCRIPTION
Resolves #77

According to @ivanistheone , the only chef that uses the`css_html_js_minify()` function used to be https://github.com/learningequality/sushi-chef-open-osmosis, but it doesn't anymore. It also appears in `sushi-chef-ck12/chef.py` but it's commented out.

The rest of Ricecooker works with Python3.4. 

## Test plan

**Before this change**

```
chef@vader:~/sushi-chef-open-osmosis$ mkvirtualenv py3.4 -p /usr/bin/python3.4
(py3.4) chef@vader:~/sushi-chef-open-osmosis$ pip install -r requirements.txt
(py3.4) chef@vader:~/sushi-chef-open-osmosis$ ./chef.py --reset --stage --token=...
```

... and get:

```
Traceback (most recent call last):
  File "./chef.py", line 27, in <module>
    from ricecooker.utils.html import download_file, WebDriver
  File "/data/.virtualenvs/py3.4/lib/python3.4/site-packages/ricecooker/utils/html.py", line 8, in <module>
    from css_html_js_minify.minify import process_multiple_files, walk2list, Pool, cpu_count, partial
  File "/data/.virtualenvs/py3.4/lib/python3.4/site-packages/css_html_js_minify/__init__.py", line 11, in <module>
    from .minify import (process_single_html_file, process_single_js_file,
  File "/data/.virtualenvs/py3.4/lib/python3.4/site-packages/css_html_js_minify/minify.py", line 28, in <module>
    from anglerfish import (check_encoding, check_folder, make_logger,
  File "/data/.virtualenvs/py3.4/lib/python3.4/site-packages/anglerfish/__init__.py", line 32, in <module>
    from anglerfish.get_clipboard import get_clipboard  # noqa
  File "/data/.virtualenvs/py3.4/lib/python3.4/site-packages/anglerfish/get_clipboard.py", line 14, in <module>
    from typing import NamedTuple
ImportError: No module named 'typing'
```

**After this change:**

```
(py3.4) chef@vader:~/sushi-chef-open-osmosis$ cd ~/ricecooker
(py3.4) chef@vader:~/ricecooker$ git checkout divad12/remove_minimize_html_css_js
(py3.4) chef@vader:~/ricecooker$ cd -
(py3.4) chef@vader:~/sushi-chef-open-osmosis$ pip install -e ../ricecooker/
(py3.4) chef@vader:~/sushi-chef-open-osmosis$ ./chef.py --reset --stage --token=...
```

... and get:

```
Logged in with username davidhu91@gmail.com
Ricecooker v0.6.13 is up-to-date.
Running get_channel...
run_id: a035f1bbca7d418aa736ce8037098735


***** Starting channel build process *****
```