### PR TITLE
Added default handling for nomonitor

### DIFF
--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -107,7 +107,8 @@ def uploadchannel(chef, update=False, thumbnails=False, download_attempts=3, res
     # Setup Sushibar client based on channel info in `get_channel`
     config.LOGGER.info("Running get_channel... ")
     channel = chef.get_channel(**kwargs)
-    config.SUSHI_BAR_CLIENT = SushiBarClient(channel, username, token, nomonitor=kwargs['nomonitor'])
+    nomonitor = kwargs.get('nomonitor', False)
+    config.SUSHI_BAR_CLIENT = SushiBarClient(channel, username, token, nomonitor=nomonitor)
 
     config.LOGGER.info("\n\n***** Starting channel build process *****\n\n")
 

--- a/ricecooker/utils/tokens.py
+++ b/ricecooker/utils/tokens.py
@@ -36,7 +36,7 @@ def get_content_curation_token(args_token):
         else:
             return args_token
     else:                                               # retrieval strategies 3
-        token = get_env('CONTENT_CURATION_TOKEN')
+        token = get_env('STUDIO_TOKEN') or get_env('CONTENT_CURATION_TOKEN')
         if token is not None:
             return token                                # 3a
         else:


### PR DESCRIPTION
This is used when calling chef.run manually, instead of calling .main() method

Also added support for `STUDIO_TOKEN` env variable for passing in token, in addition to previously supported `CONTENT_CURATION_TOKEN`, which we'll keep for backward compat.