### PR TITLE
Ensure web+graphie protocol is on KA questions

### DIFF
--- a/ricecooker/classes/questions.py
+++ b/ricecooker/classes/questions.py
@@ -181,7 +181,7 @@ class BaseQuestion:
         filename = exercise_file.process_file()
 
         # Need to replace text's web+graphie with https to get text matches
-        text = text.replace("web+graphie://", "https://").replace(path_text, exercises.CONTENT_STORAGE_FORMAT.format(exercise_file.get_replacement_str()))
+        text.replace("web+graphie://", "web+graphie:https://").replace(path_text, exercises.CONTENT_STORAGE_FORMAT.format(exercise_file.get_replacement_str()))
 
         return text, [exercise_file]
 

--- a/ricecooker/classes/questions.py
+++ b/ricecooker/classes/questions.py
@@ -181,7 +181,7 @@ class BaseQuestion:
         filename = exercise_file.process_file()
 
         # Need to replace text's web+graphie with https to get text matches
-        text.replace("web+graphie://", "web+graphie:https://").replace(path_text, exercises.CONTENT_STORAGE_FORMAT.format(exercise_file.get_replacement_str()))
+        text = text.replace("web+graphie://", "web+graphie:https://").replace(path_text, exercises.CONTENT_STORAGE_FORMAT.format(exercise_file.get_replacement_str()))
 
         return text, [exercise_file]
 


### PR DESCRIPTION
We need the `web+graphie:` protocol in order for perseus renderer to locate the correct `.svg` and `-data.json` files.