### PR TITLE
Fix/predictable zip

### DIFF
--- a/ricecooker/utils/zip.py
+++ b/ricecooker/utils/zip.py
@@ -7,12 +7,13 @@ def _read_file(path):
         return f.read()
 
 def create_predictable_zip(path):
-    """ create_predictable_zip: Create a zip file with predictable sort order and metadata, for MD5 consistency.
-        Args:
-            path (str): absolute path either to a directory to zip up, or an existing zip file to convert.
-        Returns: path (str) to the output zip file
     """
-
+    Create a zip file with predictable sort order and metadata so that MD5 will
+    stay consistent if zipping the same content twice.
+    Args:
+        path (str): absolute path either to a directory to zip up, or an existing zip file to convert.
+    Returns: path (str) to the output zip file
+    """
     # if path is a directory, recursively enumerate all the files under the directory
     if os.path.isdir(path): 
         paths = []
@@ -28,24 +29,25 @@ def create_predictable_zip(path):
         raise Exception("The `path` must either point to a directory or to a zip file.")
 
     # create a temporary zip file path to write the output into
-    zippath = tempfile.mkstemp(suffix=".zip")[1]
+    zippathfd, zippath = tempfile.mkstemp(suffix=".zip")
 
     with zipfile.ZipFile(zippath, "w") as outputzip:
         # loop over the file paths in sorted order, to ensure a predictable zip
         for filepath in sorted(paths):
             write_file_to_zip_with_neutral_metadata(outputzip, filepath, reader(filepath))
+        os.fdopen(zippathfd).close()
     return zippath
 
 
 def write_file_to_zip_with_neutral_metadata(zfile, filename, content):
-    """ write_file_to_zip_with_neutral_metadata: Write a string into an open ZipFile with predictable metadata.
-        Args:
-            zfile (ZipFile): open ZipFile to write the content into
-            filename (str): the file path within the zip file to write into
-            content (str): the content to write into the zip
-        Returns: None
     """
-
+    Write the string `content` to `filename` in the open ZipFile `zfile`.
+    Args:
+        zfile (ZipFile): open ZipFile to write the content into
+        filename (str): the file path within the zip file to write into
+        content (str): the content to write into the zip
+    Returns: None
+    """
     info = zipfile.ZipInfo(filename, date_time=(2015, 10, 21, 7, 28, 0))
     info.compress_type = zipfile.ZIP_DEFLATED
     info.comment = "".encode()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -107,21 +107,20 @@ def test_htmlfile_validate():
 def test_htmlfile_to_dict():
     assert True
 
-@pytest.mark.skipif(IS_TRAVIS_TESTING, reason="Skipping create_predictable_zip stress test.")
-def test_create_many_predictable_zip_files(ndirs=8193, nfiles=1):
+@pytest.mark.skip('Skipping one-off create_predictable_zip stress test because long running...')
+def test_create_many_predictable_zip_files(ndirs=8193):
     """
     Regression test for `OSError: [Errno 24] Too many open files` when using
     ricecooker.utils.zip.create_predictable_zip helper method:
     https://github.com/learningequality/ricecooker/issues/185
+    Run `ulimit -a` to see the limits for # open files on your system and set ndirs
+    to higher number to use this test. Also comment out the @pytest.mark.skip
     """
     zip_paths = []
-    for i in range(0, ndirs):
+    for _ in range(0, ndirs):
         inputdir = tempfile.mkdtemp()
-        for j in range(0,nfiles):
-            fname = 'file'+str(j)+'.txt'
-            f = open(os.path.join(inputdir,fname), 'w')
-            f.write('something something')
-            f.close()
+        with open(os.path.join(inputdir,'index.html'), 'w') as testf:
+            testf.write('something something')
         zip_path = create_predictable_zip(inputdir)
         zip_paths.append(zip_path)
     assert len(zip_paths) == ndirs, 'wrong number of zip files created'

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,12 +1,15 @@
 """ Tests for file downloading and processing """
-
 import pytest
 import os.path
+import tempfile
+
 from le_utils.constants import content_kinds, languages
 from ricecooker.classes.files import *
 from ricecooker.classes.files import _get_language_with_alpha2_fallback
+from ricecooker.utils.zip import create_predictable_zip
 from ricecooker import config
 
+IS_TRAVIS_TESTING = "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true"
 
 # Process all of the files
 def process_files(video_file, html_file, audio_file, document_file, thumbnail_file, subtitle_file):
@@ -103,6 +106,25 @@ def test_htmlfile_validate():
 
 def test_htmlfile_to_dict():
     assert True
+
+@pytest.mark.skipif(IS_TRAVIS_TESTING, reason="Skipping create_predictable_zip stress test.")
+def test_create_many_predictable_zip_files(ndirs=8193, nfiles=1):
+    """
+    Regression test for `OSError: [Errno 24] Too many open files` when using
+    ricecooker.utils.zip.create_predictable_zip helper method:
+    https://github.com/learningequality/ricecooker/issues/185
+    """
+    zip_paths = []
+    for i in range(0, ndirs):
+        inputdir = tempfile.mkdtemp()
+        for j in range(0,nfiles):
+            fname = 'file'+str(j)+'.txt'
+            f = open(os.path.join(inputdir,fname), 'w')
+            f.write('something something')
+            f.close()
+        zip_path = create_predictable_zip(inputdir)
+        zip_paths.append(zip_path)
+    assert len(zip_paths) == ndirs, 'wrong number of zip files created'
 
 
 """ *********** EXTRACTEDVIDEOTHUMBNAILFILE TESTS *********** """


### PR DESCRIPTION
This is a fix for  https://github.com/learningequality/ricecooker/issues/185

The issue was a little tricky detail --- the call to `tempfile.mkstemp(suffix=".zip")` opens a file descriptor `fd` (int) for this file and it's on us to close it when we're done.

Found via
https://ubuntuforums.org/showthread.php?t=919340&s=a051814d3439ffe92a8edb3edd7b583b&p=5786446#post5786446

I assume the remporary zip file will stick around after the fd is closed... it better because ricecooker will look for the zip file at this path later on.