### PR TITLE
Fix validation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # C extensions
 *.so
 
+# Development notebooks
+WIP
 
 
 # Distribution / packaging

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -346,13 +346,18 @@ class DownloadFile(File):
         super(DownloadFile, self).__init__(**kwargs)
 
     def validate(self):
+        """
+        Ensure `filename` has one of the extensions in `self.allowed_formats`.
+        """
         filename = self.get_filename()
-        assert filename, "{} must have a filename".format(self.__class__.__name__)
-        _basename, ext = os.path.splitext(filename)
-        plain_ext = ext.lstrip('.')
-        # don't validate for single-digit extension, or no extension
-        if len(plain_ext) > 1:
-            assert plain_ext in self.allowed_formats, "{} must have one of the following extensions: {} (instead, got '{}' from '{}')".format(self.__class__.__name__, self.allowed_formats, plain_ext, self.path)
+        if filename:
+            ext = extract_path_ext(filename)
+            assert ext in self.allowed_formats, "{} must have one of the following"
+            "extensions: {} (instead, got '{}' from path '{}')".format(
+                self.__class__.__name__, self.allowed_formats, ext, self.path)
+        else:
+            config.LOGGER.error("\t--- Validation failed for {} with path {}".format(
+                self.__class__.__name__, self.path))
 
     def process_file(self):
         try:

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -190,14 +190,15 @@ class Node(object):
         for child in self.children:
             child.print_tree(indent + 1)
 
-    def test_tree(self):
-        """ test_tree: validate all nodes in this tree
-            Args: None
-            Returns: boolean indicating if tree is valid
+    def validate_tree(self):
+        """
+        Validate all nodes in this tree recusively.
+          Args: None
+          Returns: boolean indicating if tree is valid
         """
         self.validate()
         for child in self.children:
-            assert child.test_tree()
+            assert child.validate_tree()
         return True
 
     def validate(self):
@@ -207,7 +208,7 @@ class Node(object):
         """
         from .files import File
 
-        assert self.source_id is not None, "Assumption Failed: Node must have an id"
+        assert self.source_id is not None, "Assumption Failed: Node must have a source_id"
         assert isinstance(self.title, str), "Assumption Failed: Node title is not a string"
         assert isinstance(self.description, str) or self.description is None, "Assumption Failed: Node description is not a string"
         assert isinstance(self.children, list), "Assumption Failed: Node children is not a list"

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -21,7 +21,7 @@ class ChannelManager:
             Args: None
             Returns: boolean indicating if tree is valid
         """
-        return self.channel.test_tree()
+        return self.channel.validate_tree()
 
     def process_tree(self, channel_node):
         """

--- a/ricecooker/utils/jsontrees.py
+++ b/ricecooker/utils/jsontrees.py
@@ -93,100 +93,112 @@ def build_tree_from_json(parent_node, sourcetree):
     for source_node in sourcetree:
         kind = source_node['kind']
         if kind not in EXPECTED_NODE_TYPES:
-            LOGGER.critical('Unexpected node type found: ' + kind)
-            raise NotImplementedError('Unexpected node type found in json data.')
+            LOGGER.critical('Unexpected node kind found: ' + kind)
+            raise NotImplementedError('Unexpected node kind found in json data.')
 
         if kind == TOPIC_NODE:
             child_node = nodes.TopicNode(
-                source_id=source_node.get("source_id", None),
-                title=source_node["title"],
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
-                thumbnail=source_node.get("thumbnail"),
+                source_id=source_node.get('source_id', None),
+                title=source_node['title'],
+                description=source_node.get('description'),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
+                thumbnail=source_node.get('thumbnail'),
             )
             parent_node.add_child(child_node)
-            source_tree_children = source_node.get("children", [])
+            source_tree_children = source_node.get('children', [])
             build_tree_from_json(child_node, source_tree_children)
 
         elif kind == VIDEO_NODE:
             child_node = nodes.VideoNode(
-                source_id=source_node["source_id"],
-                title=source_node["title"],
+                source_id=source_node['source_id'],
+                title=source_node['title'],
+                description=source_node.get('description'),
                 license=get_license(**source_node['license']),
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
                 derive_thumbnail=source_node.get('derive_thumbnail', True),  # video-specific option
                 thumbnail=source_node.get('thumbnail'),
             )
-            add_files(child_node, source_node.get("files") or [])
+            add_files(child_node, source_node.get('files') or [])
             parent_node.add_child(child_node)
 
         elif kind == AUDIO_NODE:
             child_node = nodes.AudioNode(
-                source_id=source_node["source_id"],
-                title=source_node["title"],
+                source_id=source_node['source_id'],
+                title=source_node['title'],
+                description=source_node.get('description'),
                 license=get_license(**source_node['license']),
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
             )
-            add_files(child_node, source_node.get("files") or [])
+            add_files(child_node, source_node.get('files') or [])
             parent_node.add_child(child_node)
 
         elif kind == EXERCISE_NODE:
             child_node = nodes.ExerciseNode(
-                source_id=source_node["source_id"],
-                title=source_node["title"],
+                source_id=source_node['source_id'],
+                title=source_node['title'],
+                description=source_node.get('description'),
                 license=get_license(**source_node['license']),
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
-                thumbnail=source_node.get("thumbnail"),
-                exercise_data=source_node.get("exercise_data"),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
+                thumbnail=source_node.get('thumbnail'),
+                exercise_data=source_node.get('exercise_data'),
                 questions=[],
             )
-            add_questions(child_node, source_node.get("questions") or [])
+            add_questions(child_node, source_node.get('questions') or [])
             parent_node.add_child(child_node)
 
         elif kind == DOCUMENT_NODE:
             child_node = nodes.DocumentNode(
-                source_id=source_node["source_id"],
-                title=source_node["title"],
+                source_id=source_node['source_id'],
+                title=source_node['title'],
+                description=source_node.get('description'),
                 license=get_license(**source_node['license']),
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
-                thumbnail=source_node.get("thumbnail"),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
+                thumbnail=source_node.get('thumbnail'),
             )
-            add_files(child_node, source_node.get("files") or [])
+            add_files(child_node, source_node.get('files') or [])
             parent_node.add_child(child_node)
 
         elif kind == HTML5_NODE:
             child_node = nodes.HTML5AppNode(
-                source_id=source_node["source_id"],
-                title=source_node["title"],
+                source_id=source_node['source_id'],
+                title=source_node['title'],
+                description=source_node.get('description'),
                 license=get_license(**source_node['license']),
-                author=source_node.get("author"),
-                description=source_node.get("description"),
-                language=source_node.get('language', None),
-                thumbnail=source_node.get("thumbnail"),
+                author=source_node.get('author'),
+                aggregator=source_node.get('aggregator'),
+                provider=source_node.get('provider'),
+                language=source_node.get('language'),
+                thumbnail=source_node.get('thumbnail'),
             )
-            add_files(child_node, source_node.get("files") or [])
+            add_files(child_node, source_node.get('files') or [])
             parent_node.add_child(child_node)
 
         else:
-            LOGGER.critical("Encountered an unknown kind: " + str(source_node))
+            LOGGER.critical('Encountered an unknown kind: ' + str(source_node))
             continue
 
     return parent_node
 
 
 def add_files(node, file_list):
-    EXPECTED_FILE_TYPES = [VIDEO_FILE, AUDIO_FILE, DOCUMENT_FILE, EPUB_FILE, HTML5_FILE,
-                           THUMBNAIL_FILE, SUBTITLES_FILE]
+    EXPECTED_FILE_TYPES = [VIDEO_FILE, AUDIO_FILE, DOCUMENT_FILE, EPUB_FILE,
+                           HTML5_FILE, THUMBNAIL_FILE, SUBTITLES_FILE]
 
     for f in file_list:
         file_type = f.get('file_type')
@@ -280,14 +292,14 @@ def add_files(node, file_list):
                     )
                 )
             else:
-                keys = ["language", "subtitlesformat"]
+                keys = ['language', 'subtitlesformat']
                 params = {'path': path}
                 for key in keys:
                     if key in f:
                         params[key] = f[key]
                 node.add_file(files.SubtitleFile(**params))
         else:
-            raise UnknownFileTypeError("Unrecognized file type '{0}'".format(f['path']))
+            raise UnknownFileTypeError('Unrecognized file type "{0}"'.format(f['path']))
 
 
 
@@ -339,9 +351,9 @@ def add_questions(exercise_node, question_list):
             q_obj = questions.PerseusQuestion(
                 id=q['id'],
                 raw_data=q.get('item_data'),
-                source_url=q.get('source_url') or "https://www.khanacademy.org/",
+                source_url=q.get('source_url') or 'https://www.khanacademy.org/',
             )
             exercise_node.add_question(q_obj)
 
         else:
-            raise UnknownQuestionTypeError("Unrecognized question type '{0}': accepted types are {1}".format(question_type, [key for key, value in exercises.question_choices]))
+            raise UnknownQuestionTypeError('Unrecognized question type {0}: accepted types are {1}'.format(question_type, [key for key, value in exercises.question_choices]))

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -142,17 +142,17 @@ def test_licenses(channel, topic, document, license_name, copyright_holder):
     assert not channel.license, "Channel should not have a license"
     assert not topic.license, "Topic should not have a license"
 
-def test_tree_validation(tree, invalid_tree, invalid_tree_2):
-    assert tree.test_tree(), "Valid tree should pass validation"
+def test_validate_tree(tree, invalid_tree, invalid_tree_2):
+    assert tree.validate_tree(), "Valid tree should pass validation"
 
     try:
-        invalid_tree.test_tree()
+        invalid_tree.validate_tree()
         assert False, "Invalid tree should fail validation"
     except InvalidNodeException:
         pass
 
     try:
-        invalid_tree_2.test_tree()
+        invalid_tree_2.validate_tree()
         assert False, "Invalid tree should fail validation"
     except InvalidNodeException:
         pass


### PR DESCRIPTION
The validation changes introduced in https://github.com/learningequality/ricecooker/pull/194 were problematic for the following reasons:
  - network errors would make chefs error out because they fail validation (a File object that errors out during `process_file` e.g. due to network errors does not have a filename)
  - waiting to do validation after `process_file` has been called changes the operation of ricecooker too much (CREATE TREE stage becomes one with the DOWNLOAD stage)
![screen shot 2018-11-09 at 5 32 35 pm](https://user-images.githubusercontent.com/163966/48291759-8a5c9600-e445-11e8-9366-cf12596c7229.png)


This PR is to fixes these regressions and oversights. I'm rushing this in so I can release a `0.6.24` that replaces the broken `0.6.23` release form yesterday.

The TL;DR of the changes is to esentially put back the old `DownloadFile` validate logic and ovveride it in subclasses that support format conversion instead of trying to make the base class handle all cases smartly.