### PR TITLE
An API for contentnode CRUD on Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+
+# Standard credentials (make sure never commited)
+credentials/studio.json
+credentials/studio_token.txt
+credentials/.studiotoken
+
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -88,6 +96,7 @@ celerybeat-schedule
 
 # virtualenv
 venv/
+venv3/
 ENV/
 
 # Spyder project settings

--- a/docs/developer/corrections.md
+++ b/docs/developer/corrections.md
@@ -1,0 +1,83 @@
+Studio bulk corrections
+=======================
+The command line script `corrections` allows to perform bulk corrections of 
+titles, descriptions, and other attributes for the content nodes of a channel.
+
+
+Use cases:
+  - Bulk modify titles and descriptions (e.g. to fix typos)
+  - Translate titles and/or descriptions (for sources with missing structure translations)
+  - Enhance content by adding description (case by case detail work done during QA)
+  - Add missing metadata like author, copyright holder, and tags to content nodes
+  - Perform basic structural edits to channel (remove unwanted topics and content nodes)
+
+Not use cases:
+  - Modify a few node attributes (better do manually through the Studio web interface)
+  - Structural changes (the corrections workflow does not support node moves)
+  - Global changes (if the same modification must be performed on all nodes in the
+    channel, it would be better to implement these changes during cheffing)
+
+
+Corrections workflow
+--------------------
+The starting point is an existing channel available on Studio, which we will
+identify through its Channel ID, denoted `<channel_id>` in code examples below.
+
+### Step 1: Export the channel metadata to CSV
+Export the complete metadata of the source channel as a local `.csv` file using:
+
+    corrections export <channel_id>
+
+This will create the file `corrections-export.csv` which can be opened with a
+spreadsheet program (e.g. LibreOffice). In order to allow for collaboration,
+the content of the spreadsheet must be copied to a shared google sheet with
+permissions set to allow external edits.
+
+
+### Step 2: Edit metadata
+In this step the content expert (internal or external) edits the metadata for
+each content node in the shared google sheet.
+The possible actions (first column) to apply to each row are as follows:
+  - `modify`: to apply metadata modifications to the topic or content node
+  - `delete`: to remove the topic or content node from the channel
+  - Leaving the Action column blank will leave the content node unchanged
+
+All rows with the `modify` keyword in the Action column will undergo metadata
+modifications according to the text specified in the `New *` columns of the sheet.
+
+For example, to correct typos in the title and description of a content node you must:
+  - Mark the row with Action=`modify` (first column)
+  - Add the desired title text in the column `New Title`
+  - Add the desired description text in the column `New Description`
+
+Note that not all metadata columns need to be specified. The choice of fields
+that will be edited during the `modify` operation will be selected in the next step.
+
+
+### Step 3: Apply the corrections from a google sheet
+Once the google sheet has been edited to contain all desired changes in the
+ `New *` columns, the next step is apply the corrections:
+
+    corrections apply <channel_id> --gsheet_id='<gsheet_id>' --gid=<gsheet_gid>
+
+where `<gsheet_id>` is the google sheets document identifier (take from the URL)
+and `<gsheet_gid>` is identifier of the particular sheet within the spreadsheet
+document that contains the corrections (usually `<gsheet_gid>=0`).
+
+The attributes that will be edited during the `modify` operation is specified
+using the `--modifyattrs` command line argument. For example to apply modifications
+only to the `title` and `description` attributes use the following command: 
+
+    corrections apply <channel_id> --gsheet_id='<gsheet_id>' --gid=<gsheet_gid> --modifyattrs='title,description'
+
+Using the above command will apply only the modifications only from the
+`New Title` and `New Description` columns and ignore modifications to copyright holder,
+author, and tags attributes.
+The default settings is `--modifyattrs=title,description,author,copyright_holder`.
+
+
+Status
+------
+Note the corrections workflows is considered "experimental" and to be used only
+when no other options are viable (too many edits to do manually through the Studio
+web interface).

--- a/ricecooker/utils/corrections.py
+++ b/ricecooker/utils/corrections.py
@@ -1,0 +1,192 @@
+import csv
+import os
+
+
+# CORRECTIONS STRUCTURE v0.1
+################################################################################
+NODE_ID_KEY = 'Node ID'
+SOURCE_ID_OR_CONTENT_ID_KEY = 'Source ID or Content ID'
+PATH_KEY = 'Path'
+CONTENT_KIND_KEY = 'Content Kind'
+OLD_TITLE_KEY = 'Old Title'
+NEW_TITLE_KEY = 'New Title'
+OLD_DESCR_KEY = 'Old Description'
+NEW_DESCR_KEY = 'New Description'
+OLD_TAGS_KEY = 'Old Tags'
+NEW_TAGS_KEY = 'New Tags'
+OLD_COPYRIGHT_HOLDER_KEY = 'Old Copyright Holder'
+NEW_COPYRIGHT_HOLDER_KEY = 'New Copyright Holder'
+OLD_AUTHOR_KEY = 'Old Author'
+NEW_AUTHOR_KEY = 'New Author'
+
+CORRECTIONS_HEADER = [
+    NODE_ID_KEY,
+    SOURCE_ID_OR_CONTENT_ID_KEY,
+    PATH_KEY,
+    CONTENT_KIND_KEY,
+    OLD_TITLE_KEY,
+    NEW_TITLE_KEY,
+    OLD_DESCR_KEY,
+    NEW_DESCR_KEY,
+    OLD_TAGS_KEY,
+    NEW_TAGS_KEY,
+    OLD_COPYRIGHT_HOLDER_KEY,
+    NEW_COPYRIGHT_HOLDER_KEY,
+    OLD_AUTHOR_KEY,
+    NEW_AUTHOR_KEY,
+]
+
+
+
+
+# GSHEETS_BASE = 'https://docs.google.com/spreadsheets/d/'
+# SHEET_ID = '1kPOnTVZ5vwq038x1aQNlA2AFtliLIcc2Xk5Kxr852mg'
+# STRUCTURE_SHEET_GID = '342105160'
+# SHEET_CSV_URL = GSHEETS_BASE + SHEET_ID + '/export?format=csv&gid=' + STRUCTURE_SHEET_GID
+# SHEET_CSV_PATH = 'chefdata/structure.csv'
+
+
+
+# What columns to export metadata to...
+TARGET_COLUMNS = {
+    'title': [OLD_TITLE_KEY, NEW_TITLE_KEY],
+    'description': [OLD_DESCR_KEY, NEW_DESCR_KEY],
+    'tags': [OLD_TAGS_KEY, NEW_TAGS_KEY],
+    'copyright_holder': [OLD_COPYRIGHT_HOLDER_KEY, NEW_COPYRIGHT_HOLDER_KEY],
+    'author': [OLD_AUTHOR_KEY, NEW_AUTHOR_KEY],
+}
+
+
+# default_keys = ['node_id', 'content_id'] # 'studio_id', 'source_id']
+default_export = ['title', 'description', 'tags', 'copyright_holder', 'author']
+
+
+class CorretionsCsvFile(object):
+
+    def __init__(self, csvfilepath='Corrections.csv', exportattributes=default_export):
+        self.csvfilepath = csvfilepath
+        self.exportattributes = exportattributes
+
+
+    def download_channel_tree(self, channel_id):
+        """
+        Downloads a complete studio channel_tree from the Studio API.
+        """
+        pass
+
+
+    # Export CSV metadata from external corrections
+    ############################################################################
+
+    def export_channel_tree_as_corrections_csv(self, channel_tree):
+        """
+        Create rows in Corrections.csv from a Studio channel, specified based on
+        node_id and content_id.
+        """
+        file_path = self.csvfilepath
+        if not os.path.exists(file_path):
+            with open(file_path, 'w') as csv_file:
+                csvwriter = csv.DictWriter(csv_file, CORRECTIONS_HEADER)
+                csvwriter.writeheader()
+
+        def _write_subtree(path_tuple, subtree, is_root=False):
+            print('    '*len(path_tuple) + '  - ', subtree['title'])
+            kind = subtree['kind']
+
+            # TOPIC ############################################################
+            if kind == 'topic':
+                if is_root:
+                    self.write_topic_row_from_studio_dict(path_tuple, subtree, is_root=is_root)
+                    for child in subtree['children']:
+                        _write_subtree(path_tuple, child)
+                else:
+                    self.write_topic_row_from_studio_dict(path_tuple, subtree)
+                    for child in subtree['children']:
+                        _write_subtree(path_tuple+[subtree['title']], child)
+
+            # CONTENT NODES ####################################################
+            elif kind in ['video', 'audio', 'document', 'html5']:
+                self.write_content_row_from_studio_dict(path_tuple, subtree)
+
+            # EXERCISE NODES ###################################################
+            # elif kind == 'exercise':
+            #     content_id = subtree['content_id']
+            #     self.write_exercice_row_from_studio_dict(path_tuple, subtree, content_id)
+            #     for question_dict in subtree['assessment_items']:
+            #         self.write_question_row_from_question_dict(source_id, question_dict)
+            else:
+                print('>>>>> skipping node', subtree['title'])
+
+        path_tuple = []
+        _write_subtree(path_tuple, channel_tree, is_root=True)
+
+
+    def write_common_row_attributes_from_studio_dict(self, row, studio_dict):
+        # 1. IDENTIFIERS
+        row[NODE_ID_KEY] = studio_dict['node_id']
+        row[SOURCE_ID_OR_CONTENT_ID_KEY] = studio_dict['content_id']
+        # PATH_KEY is set in specific function
+        row[CONTENT_KIND_KEY] = studio_dict['kind']
+
+        # 2. METADATA
+        for exportattr in self.exportattributes:
+            target_cols = TARGET_COLUMNS[exportattr]
+            for target_col in target_cols:
+                if exportattr == 'tags':
+                    tags = studio_dict['tags']
+                    tags_semicolon_separated = ';'.join(tags)
+                    row[target_col] = tags_semicolon_separated
+                else:
+                    row[target_col] = studio_dict[exportattr]
+
+    def write_topic_row_from_studio_dict(self, path_tuple, studio_dict, is_root=False):
+        if is_root:
+            return
+        print('Generating Corrections.csv rows for path_tuple ', path_tuple, studio_dict['title'])
+        file_path = self.csvfilepath
+        with open(file_path, 'a') as csv_file:
+            csvwriter = csv.DictWriter(csv_file, CORRECTIONS_HEADER)
+            title = studio_dict['title']
+            path_with_self = '/'.join(path_tuple+[title])
+            topic_row = {}
+            self.write_common_row_attributes_from_studio_dict(topic_row, studio_dict)
+            # WRITE TOPIC ROW
+            topic_row[PATH_KEY] = path_with_self
+            csvwriter.writerow(topic_row)
+
+    def write_content_row_from_studio_dict(self, path_tuple, studio_dict):
+        file_path = self.csvfilepath
+        with open(file_path, 'a') as csv_file:
+            csvwriter = csv.DictWriter(csv_file, CORRECTIONS_HEADER)
+            row = {}
+            self.write_common_row_attributes_from_studio_dict(row, studio_dict)
+            title = studio_dict['title']
+            row[PATH_KEY] = '/'.join(path_tuple+[title])
+            # WRITE ROW
+            csvwriter.writerow(row)
+
+
+def apply_corrections():
+    pass
+
+
+
+# 
+# url = "http://localhost:8080/api/contentnode"
+# 
+# import requests
+# 
+# [{"title":"Topic 1","id":"bc8be361e6be4ada8bc793080b6f24d5", "tags":[], "assessment_items":[], "prerequisite":[], "kind":"topic", "parent":"7463b0d9f11a441b8898ef20f74474ce"}]
+# 
+# 
+# payload = "[{\"title\":\"Topic 1\",\"id\":\"bc8be361e6be4ada8bc793080b6f24d5\", \"tags\":[], \"assessment_items\":[], \"prerequisite\":[], \"kind\":\"topic\", \"parent\":\"7463b0d9f11a441b8898ef20f74474ce\"}]\n\n"
+# headers = {
+#     'authorization': "Token <<<>>>>",
+#     'content-type': "application/json",
+#     'cache-control': "no-cache",
+#     'postman-token': "1d8e9f2b-929c-edf8-a561-a0fb41ac9606"
+#     }
+# 
+# response = requests.request("PATCH", url, data=payload, headers=headers)
+# 
+# print(response.text)

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -1,14 +1,10 @@
 import requests
-# import requests_cache
-# requests_cache.install_cache()   # RM because it makes session stuff fail...
-
 from ricecooker.config import LOGGER
 
 
 # DEFAULT_STUDIO_URL = 'https://develop.studio.learningequality.org'
 DEFAULT_STUDIO_URL = 'http://127.0.0.1:8080'
 # DEFAULT_STUDIO_URL = 'https://studio.learningequality.org'
-
 
 
 # TODO https://studio.learningequality.org/api/get_node_path/ca8f380/18932/41b2549
@@ -18,7 +14,8 @@ DEFAULT_STUDIO_URL = 'http://127.0.0.1:8080'
 
 class StudioApi(object):
     """
-    Helper class whose methods allow access to Studo API endpoints for debugging.
+    Helper class whose methods allow access to Studo API endpoints for reports,
+    corrections, and other automation.
     """
 
     def __init__(self, token, username=None, password=None, studio_url=DEFAULT_STUDIO_URL):
@@ -178,6 +175,7 @@ class StudioApi(object):
         """
         DUPLICATE_NODE_INLINE_ENDPOINT = self.studio_url + '/api/duplicate_nodes/'
         REQUIRED_FIELDS = ['id']
+        assert data_has_required_keys(data, REQUIRED_FIELDS), 'no studio_id in data'
         post_data = {
             'node_ids': [data['id']],
             'target_parent': target_parent,

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -12,6 +12,8 @@ NODES_ENDPOINT =         STUDIO_URL + '/api/get_nodes_by_ids_complete/'
 LICENSES_LIST_ENDPOINT = STUDIO_URL + '/api/license'
 CHANNEL_ENDPOINT =       STUDIO_URL + '/api/channel/'
 # TODO https://studio.learningequality.org/api/get_node_path/ca8f380/18932/41b2549
+# TODO https://studio.learningequality.org/api/language
+
 
 
 class StudioApi(object):

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -1,23 +1,65 @@
 import requests
 import requests_cache
-requests_cache.install_cache()
+# requests_cache.install_cache()   # RM because it makes session stuff fail...
 
 from ricecooker.config import LOGGER
 
 
 STUDIO_URL = 'https://studio.learningequality.org'
 
+LOGIN_ENDPOINT =         STUDIO_URL + '/accounts/login/'
 NODES_ENDPOINT =         STUDIO_URL + '/api/get_nodes_by_ids_complete/'
 LICENSES_LIST_ENDPOINT = STUDIO_URL + '/api/license'
+CHANNEL_ENDPOINT =       STUDIO_URL + '/api/channel/'
 # TODO https://studio.learningequality.org/api/get_node_path/ca8f380/18932/41b2549
-# TODO http://develop.studio.learningequality.org/api/channel/094097ce6f395ec0b50aabd04943c6b3
 
 
 class StudioApi(object):
-    def __init__(self, token):
+    """
+    Helper class whose methods allow access to Studo API endpoints for debugging.
+    """
+
+    def __init__(self, token, username=None, password=None, studio_url=STUDIO_URL):
         self.token = token
         self.licenses_by_id = self.get_licenses()
-        
+        if username and password:
+            self.session = self._create_logged_in_session(username, password)
+        else:
+            self.session = None
+
+    def _create_logged_in_session(self, username, password):
+        session = requests.session()
+        session.headers.update({"referer": STUDIO_URL})
+        session.headers.update({'User-Agent': 'Mozilla/5.0 Firefox/63.0'})
+        session.get(LOGIN_ENDPOINT)
+        csrftoken = session.cookies.get("csrftoken")
+        session.headers.update({"csrftoken": csrftoken})
+        session.headers.update({"referer": LOGIN_ENDPOINT})
+        post_data = {
+            "csrfmiddlewaretoken": csrftoken,
+            "username": username,
+            "password": password
+        }
+        response2 = session.post(LOGIN_ENDPOINT, data=post_data)
+        assert response2.status_code == 200, 'Login POST failed'
+        return session
+
+
+    def get_channel_root_studio_id(self, channel_id, tree='main'):
+        """
+        Return the `studio_id` for the root of the tree `tree` for `channel_id`.
+        """
+        # TODO: add TokenAuth to this entpoint so can use without session login
+        # headers = {"Authorization": "Token {0}".format(self.token)}
+        url = CHANNEL_ENDPOINT + channel_id
+        LOGGER.info('  GET ' + url)
+        response = self.session.get(url)
+        channel_data = response.json()
+        tree_key = tree + '_tree'
+        tree_data = channel_data[tree_key]
+        return tree_data['id']
+
+
     def get_licenses(self):
         headers = {"Authorization": "Token {0}".format(self.token)}
         response = requests.get(LICENSES_LIST_ENDPOINT, headers=headers)
@@ -27,6 +69,7 @@ class StudioApi(object):
             licenses_dict[license['id']] = license
         return licenses_dict
 
+
     def get_nodes_by_ids_complete(self, studio_id):
         headers = {"Authorization": "Token {0}".format(self.token)}
         url = NODES_ENDPOINT + studio_id
@@ -34,6 +77,7 @@ class StudioApi(object):
         response = requests.get(url, headers=headers)
         studio_node = response.json()[0]
         return studio_node
+
 
     def get_tree_for_studio_id(self, studio_id):
         """

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -7,10 +7,14 @@ from ricecooker.config import LOGGER
 
 STUDIO_URL = 'https://studio.learningequality.org'
 
+STUDIO_URL = 'http://127.0.0.1:8080'
+
 LOGIN_ENDPOINT =         STUDIO_URL + '/accounts/login/'
 NODES_ENDPOINT =         STUDIO_URL + '/api/get_nodes_by_ids_complete/'
 LICENSES_LIST_ENDPOINT = STUDIO_URL + '/api/license'
 CHANNEL_ENDPOINT =       STUDIO_URL + '/api/channel/'
+CONTENTNODE_ENDPOINT =   STUDIO_URL + '/api/contentnode'
+MOVE_NODES_ENDPOINT =    STUDIO_URL + '/api/move_nodes/'
 # TODO https://studio.learningequality.org/api/get_node_path/ca8f380/18932/41b2549
 # TODO https://studio.learningequality.org/api/language
 # TODO `api/get_total_size/(?P<ids>[^/]*)` where ids are split by commas or run this script:
@@ -47,9 +51,17 @@ class StudioApi(object):
         return session
 
 
-    def get_channel_root_studio_id(self, channel_id, tree='main'):
+    def get_channel(self, channel_id):
         """
-        Return the `studio_id` for the root of the tree `tree` for `channel_id`.
+        Calls the /api/channel/{{channel_id}} endpoint to get the channel info.
+        Returns a dictionary of useful information like:
+          - `name` and `description`
+          - `main_tree` {"id": studio_id} where `studio_id` is the root of the channel's main tree
+          - `staging_tree`: {"id": studio_id} for the root of the staging tree
+          - `trash_tree`: tree where deleted nodes go
+          - `ricecooker_version`: string that indicates what version of riccooker
+             created this channel. If `Null` this means it's a manually uploaded
+             channel or a derivative channel
         """
         # TODO: add TokenAuth to this entpoint so can use without session login
         # headers = {"Authorization": "Token {0}".format(self.token)}
@@ -57,6 +69,13 @@ class StudioApi(object):
         LOGGER.info('  GET ' + url)
         response = self.session.get(url)
         channel_data = response.json()
+        return channel_data
+
+    def get_channel_root_studio_id(self, channel_id, tree='main'):
+        """
+        Return the `studio_id` for the root of the tree `tree` for `channel_id`.
+        """
+        channel_data = self.get_channel(channel_id)
         tree_key = tree + '_tree'
         tree_data = channel_data[tree_key]
         return tree_data['id']
@@ -73,6 +92,9 @@ class StudioApi(object):
 
 
     def get_nodes_by_ids_complete(self, studio_id):
+        """
+        Get the complete JSON representation of a content node from the Studio API.
+        """
         headers = {"Authorization": "Token {0}".format(self.token)}
         url = NODES_ENDPOINT + studio_id
         LOGGER.info('  GET ' + url)
@@ -97,4 +119,68 @@ class StudioApi(object):
         _build_subtree(channel_parent, studio_id)
         channel = channel_parent['children'][0]
         return channel
+
+
+
+    def get_contentnode(self, studio_id):
+        """
+        Return the `studio_id` for the root of the tree `tree` for `channel_id`.
+        """
+        return self.get_nodes_by_ids_complete(studio_id)
+
+    def put_contentnode(self, data):
+        """
+        Send a PUT requests to /api/contentnode to update Studio node to data.
+        """
+        REQUIRED_FIELDS = ['id', 'tags', 'prerequisite', 'parent']
+        assert data_has_required_keys(data, REQUIRED_FIELDS), 'missing necessary attributes'        
+        studio_id = data['id']
+        url = CONTENTNODE_ENDPOINT
+        print('  semantic PATCH using PUT ' + url)
+        csrftoken = self.session.cookies.get("csrftoken")
+        self.session.headers.update({"x-csrftoken": csrftoken})
+        response = self.session.put(url, json=[data])
+        node_data = response.json()
+        return node_data
+
+    def delete_contentnode(self, data, channel_id, trash_studio_id=None):
+        """
+        Send a POST requests to /api/move_nodes/ to delete Studio node spcified
+        in `data` in the channel specified in `channel_id`. For efficiency, you
+        can provide `trash_studio_id` which is the studio id the trash tree for
+        the channel.
+        """
+        REQUIRED_FIELDS = ['id']
+        assert data_has_required_keys(data, REQUIRED_FIELDS), 'missing necessary attributes'
+        if trash_studio_id is None:
+            channel_data = self.get_channel(channel_id)
+            trash_studio_id = channel_data['trash_tree']['id']
+        post_data = {
+            'nodes': [data],
+            'target_parent': trash_studio_id,
+            'channel_id': channel_id,
+        }
+        url = MOVE_NODES_ENDPOINT
+        print('  semantic DELETE using POST to ' + url)
+        csrftoken = self.session.cookies.get("csrftoken")
+        self.session.headers.update({"x-csrftoken": csrftoken})
+        response = self.session.post(url, json=post_data)
+        deleted_data = response.json()
+        return deleted_data
+
+
+
+
+def data_has_required_keys(data, required_keys):
+    verdict = True
+    for key in required_keys:
+        if key not in data:
+            verdict = False
+    return verdict
+
+
+
+
+
+
 

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -150,7 +150,7 @@ class StudioApi(object):
         assert data_has_required_keys(data, REQUIRED_FIELDS), 'missing necessary attributes'        
         # studio_id = data['id']
         url = CONTENTNODE_ENDPOINT
-        print('  semantic PATCH using PUT ' + url)
+        # print('  semantic PATCH using PUT ' + url)
         csrftoken = self.session.cookies.get("csrftoken")
         self.session.headers.update({"x-csrftoken": csrftoken})
         response = self.session.put(url, json=[data])
@@ -176,7 +176,7 @@ class StudioApi(object):
             'channel_id': channel_id,
         }
         url = MOVE_NODES_ENDPOINT
-        print('  semantic DELETE using POST to ' + url)
+        # print('  semantic DELETE using POST to ' + url)
         csrftoken = self.session.cookies.get("csrftoken")
         self.session.headers.update({"x-csrftoken": csrftoken})
         response = self.session.post(url, json=post_data)
@@ -197,11 +197,10 @@ class StudioApi(object):
             'channel_id': channel_id,
         }
         url = DUPLICATE_NODE_INLINE_ENDPOINT
-        print('  semantic COPY using POST to ' + url)
+        # print('  semantic COPY using POST to ' + url)
         csrftoken = self.session.cookies.get("csrftoken")
         self.session.headers.update({"x-csrftoken": csrftoken})
         response = self.session.post(url, json=post_data)
-        print(response.content)
         copied_data_list = response.json()
         return copied_data_list
 

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -13,7 +13,7 @@ LICENSES_LIST_ENDPOINT = STUDIO_URL + '/api/license'
 CHANNEL_ENDPOINT =       STUDIO_URL + '/api/channel/'
 # TODO https://studio.learningequality.org/api/get_node_path/ca8f380/18932/41b2549
 # TODO https://studio.learningequality.org/api/language
-
+# TODO `api/get_total_size/(?P<ids>[^/]*)` where ids are split by commas or run this script:
 
 
 class StudioApi(object):

--- a/ricecooker/utils/libstudio.py
+++ b/ricecooker/utils/libstudio.py
@@ -105,7 +105,7 @@ class StudioApi(object):
         A more efficient version of `get_nodes_by_ids_complete` that GETs tree
         content node data in chunks of 10 from the Studio API.
         """
-        CHUNK_SIZE = 15
+        CHUNK_SIZE = 25
         NODES_ENDPOINT = self.studio_url + '/api/get_nodes_by_ids_complete/'
         headers = {"Authorization": "Token {0}".format(self.token)}
         studio_nodes = []

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
     "websocket-client==0.40.0",
     "mock==2.0.0",
     "pypdf2>=1.26.0",
+    "dictdiffer>=0.8.0",
 ]
 
 test_requirements = [
@@ -45,7 +46,11 @@ setup(
     url='https://github.com/learningequality/ricecooker',
     packages=find_packages(),
     package_dir={'ricecooker':'ricecooker'},
-    entry_points={},
+    entry_points = {
+        'console_scripts': [
+            'corrections = ricecooker.utils.corrections:correctionsmain',
+        ],
+    },
     include_package_data=True,
     install_requires=requirements,
     license="MIT license",


### PR DESCRIPTION
`libstudio.py` contains the `StudioApi` class with helper methods for calling Studio API endpoints

Use cases:
  - extract channel metadata (see channel as json tree with complete studio metadata)
  - corrections workflow

Currently this has only been used to change titles and descriptions , but cold be useful more generally (e.g. to add tags to content nodes).

See docs docs/developer/corrections.md for more info.