### PR TITLE
Role json and docs

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -58,6 +58,9 @@ Each node has the following attributes:
   - __language__ (str or lang_obj): language for the content node
   - __description__ (str): description of content (optional)
   - __author__ (str): who created the content (optional)
+  - __aggregator__ (str): website or org hosting the content collection but not necessarily the creator or copyright holder (optional)
+  - __provider__ (str): organization that commissioned or is distributing the content (optional)
+  - __role__ (str): set to `roles.COACH` for teacher-facing materials (default `roles.LEARNER`)
   - __thumbnail__ (str or ThumbnailFile): path to thumbnail or file object (optional)
   - __files__ ([FileObject]): list of file objects for node (optional)
   - __extra_fields__ (dict): any additional data needed for node (optional)
@@ -200,6 +203,16 @@ combinations of content node and file types.
 VideoNodes also have a __derive_thumbnail__ (boolean) argument, which will automatically
 extract a thumbnail from the video if no thumbnail is provided.
 
+
+### Role-based visibility
+It is possible to include content nodes in any channel that are only visible to
+Kolibri coaches. Setting the visibility to "coach-only" is useful for pedagogical 
+guides, answer keys, lesson plan suggestions, and other supporting material
+intended only for teachers to see but not students.
+To control content visibility set the `role` attributes to one of the constants
+defined in `le_utils.constants.roles` to define the "minimum role" needed to see the content.
+  - if `role=roles.LEARNER`: visible to learners, coaches, and administrators
+  - if `role=roles.COACH`: visible only to Kolibri coaches and administrators
 
 
 Exercise nodes

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -438,6 +438,7 @@ class ContentNode(TreeNode):
             author (str): who created the content (optional)
             aggregator (str): website or org hosting the content collection but not necessarily the creator or copyright holder (optional)
             provider (str): organization that commissioned or is distributing the content (optional)
+            role (str): set to roles.COACH for teacher-facing materials (default roles.LEARNER)
             thumbnail (str): local path or url to thumbnail image (optional)
             files ([<File>]): list of file objects for node (optional)
             extra_fields (dict): any additional data needed for node (optional)

--- a/ricecooker/utils/jsontrees.py
+++ b/ricecooker/utils/jsontrees.py
@@ -104,6 +104,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                # no role for topics (computed dynaically from descendants)
                 language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
             )
@@ -120,6 +121,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                role=source_node.get('role'),
                 language=source_node.get('language'),
                 derive_thumbnail=source_node.get('derive_thumbnail', True),  # video-specific option
                 thumbnail=source_node.get('thumbnail'),
@@ -136,6 +138,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                role=source_node.get('role'),
                 language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
             )
@@ -151,6 +154,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                role=source_node.get('role'),
                 language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
                 exercise_data=source_node.get('exercise_data'),
@@ -168,6 +172,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                role=source_node.get('role'),
                 language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
             )
@@ -183,6 +188,7 @@ def build_tree_from_json(parent_node, sourcetree):
                 author=source_node.get('author'),
                 aggregator=source_node.get('aggregator'),
                 provider=source_node.get('provider'),
+                role=source_node.get('role'),
                 language=source_node.get('language'),
                 thumbnail=source_node.get('thumbnail'),
             )


### PR DESCRIPTION
Actual implementation in https://github.com/learningequality/ricecooker/pull/156/files 
this PR adds:
  - supporting attrs in for ricecooker-json based chefs
  - minimal docs
