### PR TITLE
HTML writer: Don't read from the url if it has already been imported

### DIFF
--- a/ricecooker/utils/html_writer.py
+++ b/ricecooker/utils/html_writer.py
@@ -101,7 +101,10 @@ class HTMLWriter():
                 directory: (str) directory in zipfile to write file to (optional)
             Returns: path to file in zip
         """
-        return self.write_contents(filename, read(url), directory=directory)
+        filepath = "{}/{}".format(directory.rstrip("/"), filename) if directory else filename
+        if not self.contains(filepath):
+            self._write_to_zipfile(filepath, read(url))
+        return filepath
 
     def write_index_contents(self, contents):
         """ write_index_contents: Write main index file to zip


### PR DESCRIPTION
Since `write_contents` does a check before writing the content to the zipfile, it seems like it would be faster to have `write_url` do a similar check before reading the url