### PR TITLE
Catch invalid subtitle errors

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -15,7 +15,8 @@ from pressurecooker.encodings import get_base64_encoding, write_base64_to_file
 from pressurecooker.images import create_tiled_image
 from pressurecooker.videos import extract_thumbnail_from_video, guess_video_preset_by_resolution, compress_video, VideoCompressionError
 from pressurecooker.subtitles import build_subtitle_converter_from_file
-from pressurecooker.subtitles import LANGUAGE_CODE_UNKNOWN, InvalidSubtitleLanguageError
+from pressurecooker.subtitles import LANGUAGE_CODE_UNKNOWN
+from pressurecooker.subtitles import InvalidSubtitleFormatError, InvalidSubtitleLanguageError
 from requests.exceptions import MissingSchema, HTTPError, ConnectionError, InvalidURL, InvalidSchema
 
 from .. import config
@@ -639,12 +640,15 @@ class SubtitleFile(DownloadFile):
 
     def process_file(self):
         self.validate()
+        caught_errors = HTTP_CAUGHT_EXCEPTIONS + \
+                 (InvalidSubtitleLanguageError, InvalidSubtitleLanguageError)
+
         try:
             self.filename = self.download_and_transform_file(self.path)
             config.LOGGER.info("\t--- Downloaded {}".format(self.filename))
             return self.filename
-        # Catch errors related to reading file path and handle silently
-        except HTTP_CAUGHT_EXCEPTIONS as err:
+        # Catch errors related to reading file path and conversion, and handle silently
+        except caught_errors as err:
             self.error = err
             config.FAILED_FILES.append(self)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "requests_file",
     "requests-cache>=0.4.13",
     "beautifulsoup4>=4.6.3",
-    "pressurecooker>=0.0.24",
+    "pressurecooker>=0.0.25",
     "selenium==3.0.1",
     "youtube-dl",
     "html5lib",


### PR DESCRIPTION
The conversion of subtitle files can fail for a variety of reasons, so we should be more defensive against these errors to prevent issues with long running chefs.