### PR TITLE
Make --stage behavior the default, and add a --deploy flag…

### DIFF
--- a/docs/chefops.md
+++ b/docs/chefops.md
@@ -35,9 +35,9 @@ You can run `./sushichef.py -h` to see an always-up-to-date info about the `rice
                             [--reset | --resume]
                             [--step {INIT, CONSTRUCT_CHANNEL, CREATE_TREE, DOWNLOAD_FILES, GET_FILE_DIFF,
                                START_UPLOAD, UPLOADING_FILES, UPLOAD_CHANNEL, PUBLISH_CHANNEL,DONE, LAST}]
-                            [--prompt] [--stage] [--publish] [--daemon]
-                            [--nomonitor] [--cmdsock CMDSOCK]
-                        
+                            [--prompt] [--deploy] [--publish]
+                            [--daemon] [--nomonitor] [--cmdsock CMDSOCK]
+
     required arguments:
       --token TOKEN         Authorization token (can be token or path to file with token)
 
@@ -59,8 +59,14 @@ You can run `./sushichef.py -h` to see an always-up-to-date info about the `rice
                             --reset flag)
       --step  {INIT, ...    Step to resume progress from (must be used with --resume flag)
       --prompt              Prompt user to open the channel after creating it
-      --stage               Upload to staging tree to allow for manual
-                            verification before replacing main tree
+      --stage               (Deprecated.) Stage updated content for review. This
+                            flag is now the default and has been kept solely to
+                            maintain compatibility. Use --deploy to immediately
+                            push changes.
+      --deploy              Immediately deploy changes to channel's main tree.
+                            This operation will delete the previous channel
+                            content once upload completes. Default (recommended)
+                            behavior is to post new tree for review.
       --publish             Publish newly uploaded version of the channel
       --daemon              Run chef in daemon mode
       --nomonitor           Disable SushiBar progress monitoring

--- a/docs/developer/sushops.md
+++ b/docs/developer/sushops.md
@@ -4,7 +4,7 @@ SushOps engineers (also called ETL engineers) are responsible for making sure
 the overall content pipeline runs smoothly. Assuming the [chefops](../chefops)
 is done right, running the chef script should be as simple as running a single command.
 SushOps engineers need to make sure not only that chef is running correctly,
-but also monitor content on the Sushibar dashboard, in Kolibri Studio, and in 
+but also monitor content on the Sushibar dashboard, in Kolibri Studio, and in
 downstream remixed channels, and in Kolibri installations.
 
 SushOps is an internal role to Learning Equality but we'll document the responsibilities
@@ -44,10 +44,10 @@ Scheduled runs
 --------------
 Chefs scripts can be scheduled to run automatically on a periodic basis, e.g.,
 once a month. In between runs, chef scripts stay dormant (daemonized).
-Scheduled chefs run by default with the `--stage` argument in order not to
-accidentally overwrite the currently active content tree on Studio with a broken one.
+By default, scheduled chefs runs create staged tree in order not to accidentally
+overwrite the currently active content tree on Studio with a broken one.
 If the channel content is relatively unchanged and raises no flags for review,
-the staged tree will be ACTIVATED, and the channel PUBLISHed automatically as well.
+the staged tree can be DEPLOYed and then PUBLISHed.
 
 
 Chef inventory

--- a/docs/platform/content_workflows.md
+++ b/docs/platform/content_workflows.md
@@ -68,10 +68,9 @@ different because a version of the channel is already available:
   - `CHEF`: to upload a new version of a content channel, simply re-run the chef
     script. The newly uploaded channel tree will replace the old tree on Studio
     (assuming the `source_domain` and `source_id` of the channel haven't changed).
-    - If you pass the `--stage` command line argument to the chef script, the new
-      version of the channel will be uploaded to a "staging tree" instead of
-      replacing the current tree, which will allow you to preview the changes to
-      the channel on Studio before replacing the existing tree. Use the `DEPLOY`
+    - The new version of the channel will be uploaded to a "staging tree" instead
+      of replacing the current tree, which will allow you to preview the changes
+      to the channel on Studio before replacing the existing tree. Use the `DEPLOY`
       button on Studio to complete the upload and replace the current tree.
     - By default, ricecooker will cache all files that have been previously uploaded
       to Studio in order to avoid the need to download and compress files each

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -95,6 +95,9 @@ class BaseChef(object):
         args_namespace, options_list = self.arg_parser.parse_known_args()
         args = args_namespace.__dict__
 
+        if args['stage_deprecated']:
+            config.LOGGER.warning('DEPRECATION WARNING: --stage is now default, so the --stage flag has been deprecated and will be removed in ricecooker 1.0.')
+
         # Make sure token is provided. There are four possible ways to specify:
         #   --token=path to token-containing file
         #   --token=140fefe...1f3
@@ -293,8 +296,6 @@ class SushiChef(BaseChef):
 
     def main(self):
         args, options = self.parse_args_and_options()
-        if args['stage_deprecated']:
-            config.LOGGER.warning('DEPRECATION WARNING: --stage is now default, so the --stage flag has been deprecated and will be removed in ricecooker 1.0.')
         config.LOGGER.debug('In SushiChef.main method. args=' + str(args) + 'options=' + str(options))
         if args['daemon']:
             self.daemon_mode(args, options)

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -71,7 +71,10 @@ class BaseChef(object):
         allsteps = [step.name.upper() for step in Status]
         parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (must be used with --resume flag)')
         parser.add_argument('--prompt', action='store_true',          help='Prompt user to open the channel after creating it')
-        parser.add_argument('--stage', action='store_true',           help='Upload to staging tree to allow for manual verification before replacing main tree')
+        parser.add_argument('--stage', dest='stage_deprecated', action='store_true',
+                            help='(Deprecated.) Stage updated content for review. This flag is now the default and has been kept solely to maintain compatibility. Use --deploy to immediately push changes.')
+        parser.add_argument('--deploy', dest='stage', action='store_false',
+                            help='Immediately deploy changes to channel\'s main tree. This operation will delete the previous channel content once upload completes. Default (recommended) behavior is to post new tree for review.')
         parser.add_argument('--publish', action='store_true',         help='Publish newly uploaded version of the channel')
         # [OPTIONS] --- extra key=value options are supported, but do not appear in help
         self.arg_parser = parser
@@ -290,14 +293,13 @@ class SushiChef(BaseChef):
 
     def main(self):
         args, options = self.parse_args_and_options()
+        if args['stage_deprecated']:
+            config.LOGGER.warning('DEPRECATION WARNING: --stage is now default, so the --stage flag has been deprecated and will be removed in ricecooker 1.0.')
         config.LOGGER.debug('In SushiChef.main method. args=' + str(args) + 'options=' + str(options))
         if args['daemon']:
             self.daemon_mode(args, options)
         else:
             self.run(args, options)
-
-
-
 
 
 # JSON TREE CHEF

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -158,6 +158,7 @@ def dict_compare(d1, d2):
 
 """ *********** CLI ARGUMENTS TESTS *********** """
 
+@pytest.mark.skip('Deprecated test that check backward compatibility with docop')
 def test_same_as_docopt(command_line_inputs):
     for line in command_line_inputs:
         arguments, kwargs = old_arguments_parser(line)


### PR DESCRIPTION
…to make overwriting tree contents an explicit option.