### PR TITLE
Hotfix for logging error when FAILED_FILES exits

### DIFF
--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -56,14 +56,18 @@ class ChannelManager:
         if len(config.FAILED_FILES) > 0:
             config.LOGGER.error("   {} file(s) have failed to download".format(len(config.FAILED_FILES)))
             for f in config.FAILED_FILES:
-                title = "{0} {id}".format(f.node.kind.capitalize(), id=f.node.source_id)\
-                        if f.node else "{0} {id}".format("Question", id=f.assessment_item.source_id)
+                if f.node:              # files associated with a a content node
+                    info = "{0} {id}".format(f.node.kind.capitalize(), id=f.node.source_id)
+                elif f.assessment_item:  # files associated with an assessment item
+                    info = "{0} {id}".format("Question", id=f.assessment_item.source_id)
+                else:   # files not associated with a node or an assessment item
+                    info = f.__class__.__name__
                 file_identifier = f.__dict__
                 if hasattr(f, 'path') and f.path:
                     file_identifier = f.path
                 elif hasattr(f, 'youtube_url') and f.youtube_url:
                     file_identifier = f.youtube_url
-                config.LOGGER.warning("\t{0}: {id} \n\t   {err}".format(title, id=file_identifier, err=f.error))
+                config.LOGGER.warning("\t{0}: {id} \n\t   {err}".format(info, id=file_identifier, err=f.error))
         else:
             config.LOGGER.info("   All files were successfully downloaded")
 


### PR DESCRIPTION
The logging warnings for FAILED_FILES errors out because `ThumbnailFile`s are not associated with any node.

This change fixes that. Releasing as "hotfix" 0.6.40 ASAP to avoid others running into the problem introduced in 0.6.39.