### PR TITLE
Check for commonly used template domain and IDs

### DIFF
--- a/docs/examples/languages.ipynb
+++ b/docs/examples/languages.ipynb
@@ -152,15 +152,14 @@
     "    \"\"\"\n",
     "    A sushi chef that creates a channel with content in EN, FR, and SP.\n",
     "    \"\"\"\n",
-    "    def get_channel(self, **kwargs):\n",
-    "        channel = ChannelNode(\n",
-    "            source_domain='testing.org',      # change me!\n",
-    "            source_id='lang_test_chanl',      # change me!\n",
-    "            title='Languages test channel',\n",
-    "            thumbnail=None, #  'https://edoc.coe.int/4115/postcard-47-flags.jpg',\n",
-    "            language = getlang('mul').code# set global language for channel (will apply as default option to all content items in this channel)\n",
-    "        )\n",
-    "        return channel\n",
+    "    channel_info = {\n",
+    "        'CHANNEL_TITLE': 'Languages test channel',\n",
+    "        'CHANNEL_SOURCE_DOMAIN': '<yourdomain.org>',     # where you got the content\n",
+    "        'CHANNEL_SOURCE_ID': '<unique id for channel>',  # channel's unique id  CHANGE ME!!\n",
+    "        'CHANNEL_LANGUAGE': getlang('mul').code,         # set global language for channel\n",
+    "        'CHANNEL_DESCRIPTION': 'This channel contains nodes in multiple languages',\n",
+    "        'CHANNEL_THUMBNAIL': None,                       # (optional)\n",
+    "    }\n",
     "\n",
     "    def construct_channel(self, **kwargs):\n",
     "        # create channel\n",
@@ -320,9 +319,8 @@
      "output_type": "stream",
      "text": [
       "[youtube] FN12ty5ztAs: Downloading webpage\n",
-      "[youtube] FN12ty5ztAs: Downloading video info webpage\n",
       "[youtube] FN12ty5ztAs: Downloading MPD manifest\n",
-      "dict_keys([])\n"
+      "dict_keys(['en', 'fr', 'zu'])\n"
      ]
     }
    ],
@@ -365,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,8 +395,8 @@
     "    A sushi chef that creates a channel with content in EN, FR, and SP.\n",
     "    \"\"\"\n",
     "    channel_info = {\n",
-    "        'CHANNEL_SOURCE_DOMAIN': 'learningequality.org',        # change me!\n",
-    "        'CHANNEL_SOURCE_ID': 'sample_youtube_video_with_subs',  # change me!\n",
+    "        'CHANNEL_SOURCE_DOMAIN': '<yourdomain.org>',     # where you got the content\n",
+    "        'CHANNEL_SOURCE_ID': '<unique id for channel>',  # channel's unique id  CHANGE ME!!\n",
     "        'CHANNEL_TITLE': 'Youtube subtitles downloading chef',\n",
     "        'CHANNEL_LANGUAGE': 'en',\n",
     "        'CHANNEL_THUMBNAIL': 'https://edoc.coe.int/4115/postcard-47-flags.jpg',\n",
@@ -410,7 +408,7 @@
     "        channel = self.get_channel(**kwargs)\n",
     "\n",
     "        # get all subtitles available for a sample video\n",
-    "        youtube_id =  'FN12ty5ztAs'\n",
+    "        youtube_id ='FN12ty5ztAs'\n",
     "        info = ydl.extract_info(youtube_id, download=False)\n",
     "        subtitle_languages = info[\"subtitles\"].keys()\n",
     "        print('Found subtitle_languages = ', subtitle_languages)\n",
@@ -445,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -462,22 +460,34 @@
       "\u001b[32mINFO    \u001b[0m \u001b[34m   Setting up initial channel structure... \u001b[0m\n",
       "\u001b[32mINFO    \u001b[0m \u001b[34m   Validating channel structure...\u001b[0m\n",
       "\u001b[32mINFO    \u001b[0m \u001b[34m      Youtube subtitles downloading chef (ChannelNode): 1 descendant\u001b[0m\n",
-      "\u001b[32mINFO    \u001b[0m \u001b[34m         Youtube video (VideoNode): 1 file\u001b[0m\n",
+      "\u001b[32mINFO    \u001b[0m \u001b[34m         Youtube video (VideoNode): 4 files\u001b[0m\n",
       "\u001b[32mINFO    \u001b[0m \u001b[34m   Tree is valid\n",
       "\u001b[0m\n",
       "\u001b[32mINFO    \u001b[0m \u001b[34mDownloading files...\u001b[0m\n",
       "\u001b[32mINFO    \u001b[0m \u001b[34mProcessing content...\u001b[0m\n",
-      "\u001b[32mINFO    \u001b[0m \u001b[34m\t--- Downloaded (YouTube) a144a6af6977247684d2a3977dc6f841.mp4\u001b[0m\n",
-      "\u001b[32mINFO    \u001b[0m \u001b[34m\t--- Downloaded 5f22a71e53271eb2d2abe013457a625d.jpg\u001b[0m\n",
-      "\u001b[32mINFO    \u001b[0m \u001b[34m   All files were successfully downloaded\u001b[0m\n",
-      "\u001b[32mINFO    \u001b[0m \u001b[34mCommand is dryrun so we are not uploading chanel.\u001b[0m\n"
+      "\u001b[32mINFO    \u001b[0m \u001b[34m\t--- Downloaded (YouTube) a144a6af6977247684d2a3977dc6f841.mp4\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found subtitle_languages =  dict_keys([])\n"
+      "Found subtitle_languages =  dict_keys(['en', 'fr', 'zu'])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO    \u001b[0m \u001b[34m\t--- Downloaded 5f22a71e53271eb2d2abe013457a625d.jpg\u001b[0m\n",
+      "\u001b[31mERROR   \u001b[0m \u001b[34m   3 file(s) have failed to download\u001b[0m\n",
+      "\u001b[33mWARNING \u001b[0m \u001b[34m\tVideo FN12ty5ztAs: http://www.youtube.com/watch?v=FN12ty5ztAs \n",
+      "\t   Subtitle with langauge en is not available for http://www.youtube.com/watch?v=FN12ty5ztAs\u001b[0m\n",
+      "\u001b[33mWARNING \u001b[0m \u001b[34m\tVideo FN12ty5ztAs: http://www.youtube.com/watch?v=FN12ty5ztAs \n",
+      "\t   Subtitle with langauge fr is not available for http://www.youtube.com/watch?v=FN12ty5ztAs\u001b[0m\n",
+      "\u001b[33mWARNING \u001b[0m \u001b[34m\tVideo FN12ty5ztAs: http://www.youtube.com/watch?v=FN12ty5ztAs \n",
+      "\t   Subtitle with langauge zul is not available for http://www.youtube.com/watch?v=FN12ty5ztAs\u001b[0m\n",
+      "\u001b[32mINFO    \u001b[0m \u001b[34mCommand is dryrun so we are not uploading chanel.\u001b[0m\n"
      ]
     }
    ],
@@ -538,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -260,6 +260,20 @@ class BaseChef(object):
             return channel
 
         elif hasattr(self, 'channel_info'):
+            # Before going any further, make sure there aren't template id values in their channel info.
+            template_domains = ['<yourdomain.org>']
+            using_template_domain = self.channel_info['CHANNEL_SOURCE_DOMAIN'] in template_domains
+            if using_template_domain:
+                config.LOGGER.error("Template source domain detected. Please set CHANNEL_SOURCE_DOMAIN before running this chef.")
+
+            template_ids = ['<unique id for the channel>', '<yourid>']
+            using_template_source_id = self.channel_info['CHANNEL_SOURCE_ID'] in template_ids
+            if using_template_source_id:
+                config.LOGGER.error("Template source ID deteected. Please set CHANNEL_SOURCE_ID before running this chef.")
+
+            if using_template_domain or using_template_source_id:
+               sys.exit(1)
+
             # If a sublass has an `channel_info` attribute (a dict) it doesn't need
             # to define a `get_channel` method and instead rely on this code:
             channel = ChannelNode(

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -260,16 +260,16 @@ class BaseChef(object):
             return channel
 
         elif hasattr(self, 'channel_info'):
-            # Before going any further, make sure there aren't template id values in their channel info.
+            # Before going any further, make sure there aren't template id values in channel_info
             template_domains = ['<yourdomain.org>']
             using_template_domain = self.channel_info['CHANNEL_SOURCE_DOMAIN'] in template_domains
             if using_template_domain:
-                config.LOGGER.error("Template source domain detected. Please set CHANNEL_SOURCE_DOMAIN before running this chef.")
+                config.LOGGER.error("Template source domain detected. Please change CHANNEL_SOURCE_DOMAIN before running this chef.")
 
             template_ids = ['<unique id for the channel>', '<yourid>']
             using_template_source_id = self.channel_info['CHANNEL_SOURCE_ID'] in template_ids
             if using_template_source_id:
-                config.LOGGER.error("Template source ID deteected. Please set CHANNEL_SOURCE_ID before running this chef.")
+                config.LOGGER.error("Template channel source ID detected. Please change CHANNEL_SOURCE_ID before running this chef.")
 
             if using_template_domain or using_template_source_id:
                sys.exit(1)


### PR DESCRIPTION
While going through the docs I realized we have been pretty consistent about the template placeholders we have used in the docs and examples, so I thought an easy fix is just to check for them and report them as an error. (Because they've already been used on Studio they won't work anyway.) 