### PR TITLE
Make --reset behavior the default rather than --resume.

### DIFF
--- a/docs/chefops.md
+++ b/docs/chefops.md
@@ -11,32 +11,30 @@ This listing shows the `ricecooker` command line interface (CLI) arguments:
 
     usage: sushichef.py  [-h] [--token TOKEN] [-u] [-v] [--quiet] [--warn]
                             [--debug] [--compress] [--thumbnails]
-                            [--reset | --resume]
-                            [--step {INIT, CONSTRUCT_CHANNEL, CREATE_TREE, DOWNLOAD_FILES, GET_FILE_DIFF,
-                               START_UPLOAD, UPLOADING_FILES, UPLOAD_CHANNEL, PUBLISH_CHANNEL,DONE, LAST}]
+                            [--resume]  [--step {CONSTRUCT_CHANNEL, CREATE_TREE,
+                                                 DOWNLOAD_FILES, GET_FILE_DIFF,
+                                                 START_UPLOAD, UPLOAD_CHANNEL}]
                             [--deploy] [--publish]
-                            
+
     required arguments:
-      --token TOKEN         Access token (can be token or path to file with token)
-      
+      --token TOKEN         Studio API Access Token (specify wither the token
+                            value or the path of a file that contains the token).
+
     optional arguments:
       -h, --help            show this help message and exit
-      -v, --verbose         Verbose mode
-      --debug               Print debugging log info to stderr
-      --compress            Compress high resolution videos to low resolution videos
-      --thumbnails          Automatically generate thumbnails for topics
-      --reset               Restart session, overwriting previous session
-      --resume              Resume from ricecooker step
+      --debug               Print extra debugging infomation.
+      -v, --verbose         Verbose mode (default).
+      --compress            Compress videos using ffmpeg -crf=32 -b:a 32k mono.
+      --thumbnails          Automatically generate thumbnails for content nodes.
+      --resume              Resume chef session from a specified step.
       --step  {INIT, ...    Step to resume progress from (must be used with --resume flag)
       --update              Force re-download of files (skip .ricecookerfilecache/ check)
-      --sample SIZE         Upload a sample of SIZE content nodes from the channel
+      --sample SIZE         Upload a sample of SIZE nodes from the channel.
       --deploy              Immediately deploy changes to channel's main tree.
-                            This operation will delete the previous channel
-                            content once upload completes. Default (recommended)
-                            behavior is to post new tree for review.
-      --publish             Publish newly uploaded version of the channel
-      --daemon              Run chef in daemon mode
-
+                            This operation will overwrite the previous channel
+                            content. Use only during development.
+      --publish             Publish newly uploaded version of the channel.
+      --daemon              Run chef in daemon mode lisenting to commands.
 
 As you can tell, there are lot of arguments to choose from, and this is not even
 the complete list: you'll have to run `./sushichef.py -h` to see the latest version.
@@ -49,13 +47,6 @@ specific nodes and files in the channel, or use `--compress` and `--thumbnails`
 to apply compression to ALL videos, and automatically generate thumbnails for
 all the supported content kinds. **We recommend you always use the `--thumbnails`**
 in order to create more colorful, lively channels that learners will want to browse.
-
-
-### Resuming and resetting chef runs
-If your `ricecooker` session gets interrupted, you can resume from any step that
-has already completed using `--resume --step=<step>` option.
-More commonly, we want to start the chef run from the beginning.
-The `--reset` flag is often given to avoid the "do you want to resume?" prompt.
 
 
 ### Caching
@@ -148,7 +139,7 @@ time to complete so it is best to run them on a dedicated server for this purpos
   - Clone the sushi chef git repository in the `/data` folder on the server
   - Run the chef script as follows `nohup <chef cmd> &`, where `<chef cmd>`
     is contains the entire script name and command line options,
-    e.g. `./sushichef.py -v --reset --token=... --thumbnails lang=fr`.
+    e.g. `./sushichef.py --token=... --thumbnails lang=fr`.
   - By default `nohup` logs stderr and stdout output to a file called `nohup.out`
     in the current working directory. Use `tail -f nohup.out` to follow this log file.
 

--- a/docs/developer/design_cli.md
+++ b/docs/developer/design_cli.md
@@ -2,7 +2,7 @@ Command line interface
 ======================
 
 This document describes logic `ricecooker` uses to parse command line arguments.
-Under normal use cases you shouldn't need modify the command line parsing, but 
+Under normal use cases you shouldn't need modify the command line parsing, but
 you need to understand how `argparse` works if you want to add new command line
 arguments for your chef script.
 
@@ -152,7 +152,7 @@ There are three types of arguments involved in a chef run:
 
   - `args` (dict): command line args as parsed by the sushi chef class and its parents
     - BaseChef: the method ` BaseChef.__init__` configures argparse for the following:
-        - `compress`, `download_attempts`, `prompt`, `publish`, `reset`, `resume`,
+        - `compress`, `download_attempts`, `prompt`, `publish`, `resume`,
           `stage`, `step`, `thumbnails`, `token`, `update`, `verbose`, `warn`
         - in compatibility mode, also handles `uploadchannel` and `chef_script` positional arguments
     - SushiChef:

--- a/docs/examples/exercises.ipynb
+++ b/docs/examples/exercises.ipynb
@@ -176,8 +176,7 @@
    "source": [
     "chef = ExercisesChef()\n",
     "args = {\n",
-    "    'command': 'dryrun',  # use  'uploadchannel'  for real run \n",
-    "    'reset': True,\n",
+    "    'command': 'dryrun',  # use  'uploadchannel'  for real run\n",
     "    'verbose': True,\n",
     "    'token': 'YOURTOKENHERE9139139f3a23232'\n",
     "}\n",

--- a/docs/examples/languages.ipynb
+++ b/docs/examples/languages.ipynb
@@ -266,8 +266,7 @@
    "source": [
     "mychef = MultipleLanguagesChef()\n",
     "args = {\n",
-    "    'command': 'dryrun',  # use  'uploadchannel'  for real run \n",
-    "    'reset': True,\n",
+    "    'command': 'dryrun',  # use  'uploadchannel'  for real run\n",
     "    'verbose': True,\n",
     "    'token': 'YOURTOKENHERE9139139f3a23232'\n",
     "}\n",
@@ -483,8 +482,7 @@
    "source": [
     "chef = YoutubeVideoWithSubtitlesSushiChef()\n",
     "args = {\n",
-    "    'command': 'dryrun',  # use  'uploadchannel'  for real run \n",
-    "    'reset': True,\n",
+    "    'command': 'dryrun',  # use  'uploadchannel'  for real run\n",
     "    'verbose': True,\n",
     "    'token': 'YOURTOKENHERE9139139f3a23232'\n",
     "}\n",

--- a/docs/tutorial/explanations.md
+++ b/docs/tutorial/explanations.md
@@ -56,7 +56,7 @@ class SimpleChef(SushiChef):                                                 # (
 if __name__ == '__main__':                                                   # (12)
     """
     Run this script on the command line using:
-        python simple_chef.py -v --reset --token=YOURTOKENHERE9139139f3a23232
+        python simple_chef.py  --token=YOURTOKENHERE9139139f3a23232
     """
     simple_chef = SimpleChef()
     simple_chef.main()                                                       # (13)
@@ -165,13 +165,10 @@ The `--update` must be used whenever files are modified but the path stays the s
 ### Command line interface
 You can run your chef script by passing the appropriate command line arguments:
 
-    ./sushichef.py -v --reset --token=YOURTOKENHERE9139139f3a23232
+    ./sushichef.py --token=YOURTOKENHERE9139139f3a23232
 
 The most important argument when running a chef script is `--token` which is used
 to pass in the Studio Access Token obtained in Step 1.
-The flags `-v` (verbose) and `--reset` are generally useful in development.
-These make sure the chef script will start the process from scratch and displays
-useful debugging information on the command line.
 
 To see the full list of `ricecooker` command line options, run `./sushichef.py -h`.
 For more details about running chef scripts see the [chefops page](../chefops.md).

--- a/docs/tutorial/gettingstarted.rst
+++ b/docs/tutorial/gettingstarted.rst
@@ -90,13 +90,10 @@ You can run a chef script by calling it on the command line:
 
 .. code:: bash
 
-    python sushichef.py --reset --token=<your-access-token>
+    python sushichef.py  --token=<your-access-token>
 
 The most important argument when running a chef script is ``--token``, which is
 used to pass in the Studio Access Token and authenticates you in Kolibri Studio.
-The flag ``--reset`` is generally useful in development. It ensures the chef script
-starts the upload process from scratch every time you run the script
-(otherwise the script will prompt you to resume from the last saved checkpoint).
 To see all the ``ricecooker`` command line options, run ``python sushichef.py -h``.
 For more details about running chef scripts see the `chefops page <../chefops.html>`__.
 
@@ -111,7 +108,7 @@ If the command succeeds, you should see something like this printed in your term
 
 .. parsed-literal::
 
-    In SushiChef.run method. args={'command': 'uploadchannel', 'token': '<your-access-token>', 'update': False, 'reset': True, 'resume': False, 'stage': True, 'publish': False} options={}
+    In SushiChef.run method. args={'command': 'uploadchannel', 'token': '<your-access-token>', 'update': False, 'resume': False, 'stage': True, 'publish': False} options={}
     Logged in with username you@yourdomain.org
     Ricecooker v0.6.42 is up-to-date.
 

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -45,7 +45,7 @@ Step 3: Edit the channel metadata
 
 Try running the sushi chef by entering the following command in your terminal::
 
-    python --reset sushichef.py --token=<your-access-token>
+    python sushichef.py  --token=<your-access-token>
 
 Click the link to `Kolibri Studio <https://studio.learningequality.org/>`__ that
 shows up in the final step and make sure your channel looks OK.

--- a/examples/gettingstarted/sushichef.py
+++ b/examples/gettingstarted/sushichef.py
@@ -39,7 +39,7 @@ class SimpleChef(SushiChef):
 if __name__ == "__main__":
     """
     Run this script on the command line using:
-        python sushichef.py --reset --token=YOURTOKENHERE9139139f3a23232
+        python sushichef.py  --token=YOURTOKENHERE9139139f3a23232
     """
     simple_chef = SimpleChef()
     simple_chef.main()

--- a/examples/oldexamples/wikipedia_video_chef.py
+++ b/examples/oldexamples/wikipedia_video_chef.py
@@ -143,14 +143,14 @@ def process_wikipedia_page(content, baseurl, destpath, **kwargs):
 if __name__ == '__main__':
     """
     Call this script using:
-        ./wikipedia_video_chef.py -v --token=<t> --reset
+        ./wikipedia_video_chef.py --token=<t>
     """
     wikichef = WikipediaVideoChef()
     wikichef.main()
 
 
 # Run the chef using
-#   ./wikipedia_video_chef.py  -v --reset --thumbnails --token=<yourstudiotoken>
+#   ./wikipedia_video_chef.py  --thumbnails --token=<yourstudiotoken>
 # and you should see something like:
 #
 #    Downloading https://commons.wikimedia.org/w/api.php?action=timedtext&title=File%3AA_Is_for_Atom_1953.webm&lang=en&trackformat=srt

--- a/examples/wikipedia/sushichef.py
+++ b/examples/wikipedia/sushichef.py
@@ -168,7 +168,7 @@ def process_wikipedia_page(content, baseurl, destpath, **kwargs):
 if __name__ == '__main__':
     """
     Call this script using:
-        ./wikipedia_chef.py -v --token=<t> --reset
+        ./wikipedia_chef.py --token=<t>
     """
     wikichef = WikipediaChef()
     wikichef.main()

--- a/ricecooker/__main__.py
+++ b/ricecooker/__main__.py
@@ -3,7 +3,7 @@ from ricecooker.chefs import BaseChef
 if __name__ == '__main__':
     """
     Entry point used when starting a sushichef using the ricecooker as a module:
-        python -m ricecooker uploadchannel --token=123 --reset  ...
+        python -m ricecooker uploadchannel --token=<studio-access-token>
     """
     chef = BaseChef(compatibility_mode=True)
     chef.main()

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -70,17 +70,16 @@ class BaseChef(object):
         parser.add_argument('--compress', action='store_true',        help='Compress high resolution videos to low resolution videos')
         parser.add_argument('--thumbnails', action='store_true',      help='Automatically generate thumbnails for topics')
         parser.add_argument('--download-attempts',type=int,default=3, help='Maximum number of times to retry downloading files')
-        rrgroup = parser.add_mutually_exclusive_group()
-        rrgroup.add_argument('--reset', dest="reset_deprecated", action='store_true',
-                                                                      help='(Deprecated.) This is now the default. Restart session, overwriting previous session (cannot be used with --resume flag)')
-        rrgroup.add_argument('--resume', action='store_true',         help='Resume from ricecooker step (cannot be used with --reset flag)')
+        parser.add_argument('--reset', dest="reset_deprecated", action='store_true',
+                                                                      help='(Deprecated.) Restarting the chef session is now the default')
+        parser.add_argument('--resume', action='store_true',          help='Resume chef session from a specified step')
         allsteps = [step.name.upper() for step in Status]
-        parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (must be used with --resume flag)')
+        parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (use in conjunction with the --resume flag)')
         parser.add_argument('--prompt', action='store_true',          help='Prompt user to open the channel after creating it')
         parser.add_argument('--stage', dest='stage_deprecated', action='store_true',
-                            help='(Deprecated.) Stage updated content for review. This flag is now the default and has been kept solely to maintain compatibility. Use --deploy to immediately push changes.')
+                                                                      help='(Deprecated.) Stage updated content for review. Uploading to a staging tree is now the default behavior. Use --deploy to upload immediately to the main tree.')
         parser.add_argument('--deploy', dest='stage', action='store_false',
-                            help='Immediately deploy changes to channel\'s main tree. This operation will delete the previous channel content once upload completes. Default (recommended) behavior is to post new tree for review.')
+                                                                      help='Immediately deploy changes to channel\'s main tree. This operation will overwrite the previous channel content. Use only in development.')
         parser.add_argument('--publish', action='store_true',         help='Publish newly uploaded version of the channel')
         parser.add_argument('--sample', type=int, metavar='SIZE',     help='Upload a sample of SIZE content nodes from the channel')
 
@@ -117,10 +116,10 @@ class BaseChef(object):
 
         # Print CLI deprecation warnings info
         if args['stage_deprecated']:
-            config.LOGGER.warning('DEPRECATION WARNING: --stage is now default, so the --stage flag has been deprecated and will be removed in ricecooker 1.0.')
+            config.LOGGER.warning('DEPRECATION WARNING: --stage is now the default bevavior. The --stage flag has been deprecated and will be removed in ricecooker 1.0.')
         if args['reset_deprecated']:
             config.LOGGER.warning(
-                'DEPRECATION WARNING: --reset is now default, so the --reset flag has been deprecated and will be removed in ricecooker 1.0.')
+                'DEPRECATION WARNING: --reset is now the default bevavior. The --reset flag has been deprecated and will be removed in ricecooker 1.0.')
         if args['publish'] and args['stage']:
             raise InvalidUsageException('The --publish argument must be used together with --deploy argument.')
         logging_args = [key for key in ['quiet', 'warn', 'debug'] if args[key]]

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -71,7 +71,8 @@ class BaseChef(object):
         parser.add_argument('--thumbnails', action='store_true',      help='Automatically generate thumbnails for topics')
         parser.add_argument('--download-attempts',type=int,default=3, help='Maximum number of times to retry downloading files')
         rrgroup = parser.add_mutually_exclusive_group()
-        rrgroup.add_argument('--reset', action='store_true',          help='Restart session, overwriting previous session (cannot be used with --resume flag)')
+        rrgroup.add_argument('--reset', dest="reset_deprecated", action='store_true',
+                                                                      help='(Deprecated.) This is now the default. Restart session, overwriting previous session (cannot be used with --resume flag)')
         rrgroup.add_argument('--resume', action='store_true',         help='Resume from ricecooker step (cannot be used with --reset flag)')
         allsteps = [step.name.upper() for step in Status]
         parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (must be used with --resume flag)')
@@ -117,6 +118,9 @@ class BaseChef(object):
         # Print CLI deprecation warnings info
         if args['stage_deprecated']:
             config.LOGGER.warning('DEPRECATION WARNING: --stage is now default, so the --stage flag has been deprecated and will be removed in ricecooker 1.0.')
+        if args['reset_deprecated']:
+            config.LOGGER.warning(
+                'DEPRECATION WARNING: --reset is now default, so the --reset flag has been deprecated and will be removed in ricecooker 1.0.')
         if args['publish'] and args['stage']:
             raise InvalidUsageException('The --publish argument must be used together with --deploy argument.')
         logging_args = [key for key in ['quiet', 'warn', 'debug'] if args[key]]

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -58,30 +58,30 @@ class BaseChef(object):
             description="Ricecooker puts your content in the conten server.",
             add_help=(self.__class__ == BaseChef)  # only add help if not subclassed
         )
-        parser.add_argument('command', nargs='?', default='uploadchannel', help='Desired action: dryrun or uploadchannel')
+        parser.add_argument('command', nargs='?', default='uploadchannel', help='Desired action: dryrun or uploadchannel (default).')
         if self.compatibility_mode:
             parser.add_argument('chef_script', help='Path to chef script file')
-        parser.add_argument('--token', default='#',                   help='Authorization token (can be token or path to file with token)')
-        parser.add_argument('-u', '--update', action='store_true',    help='Force re-download of files (skip .ricecookerfilecache/ check)')
-        parser.add_argument('-v', '--verbose', action='store_true', default=True, help='Verbose mode')
-        parser.add_argument('--quiet', action='store_true',           help='Print only errors to stderr')
-        parser.add_argument('--warn', action='store_true',            help='Print warnings to stderr')
-        parser.add_argument('--debug', action='store_true',           help='Print debugging log info to stderr')
-        parser.add_argument('--compress', action='store_true',        help='Compress high resolution videos to low resolution videos')
-        parser.add_argument('--thumbnails', action='store_true',      help='Automatically generate thumbnails for topics')
-        parser.add_argument('--download-attempts',type=int,default=3, help='Maximum number of times to retry downloading files')
-        parser.add_argument('--reset', dest="reset_deprecated", action='store_true',
-                                                                      help='(Deprecated.) Restarting the chef session is now the default')
-        parser.add_argument('--resume', action='store_true',          help='Resume chef session from a specified step')
+        parser.add_argument('--token', default='#',                   help='Studio API Access Token (specify wither the token value or the path of a file that contains the token).')
+        parser.add_argument('-u', '--update', action='store_true',    help='Force file re-download (skip .ricecookerfilecache/).')
+        parser.add_argument('--debug', action='store_true',           help='Print extra debugging infomation.')
+        parser.add_argument('-v', '--verbose', action='store_true', default=True, help='Verbose mode (default).')
+        parser.add_argument('--warn', action='store_true',            help='Print errors and warnings.')
+        parser.add_argument('--quiet', action='store_true',           help='Print only errors.')
+        parser.add_argument('--compress', action='store_true',        help='Compress videos using ffmpeg -crf=32 -b:a 32k mono.')
+        parser.add_argument('--thumbnails', action='store_true',      help='Automatically generate thumbnails for content nodes.')
+        parser.add_argument('--download-attempts',type=int,default=3, help='Maximum number of times to retry downloading files.')
+        parser.add_argument('--resume', action='store_true',          help='Resume chef session from a specified step.')
         allsteps = [step.name.upper() for step in Status]
-        parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (use in conjunction with the --resume flag)')
-        parser.add_argument('--prompt', action='store_true',          help='Prompt user to open the channel after creating it')
-        parser.add_argument('--stage', dest='stage_deprecated', action='store_true',
-                                                                      help='(Deprecated.) Stage updated content for review. Uploading to a staging tree is now the default behavior. Use --deploy to upload immediately to the main tree.')
+        parser.add_argument('--step',choices=allsteps,default='LAST', help='Step to resume progress from (use with the --resume).')
+        parser.add_argument('--prompt', action='store_true',          help='Prompt user to open the channel after the chef run.')
         parser.add_argument('--deploy', dest='stage', action='store_false',
-                                                                      help='Immediately deploy changes to channel\'s main tree. This operation will overwrite the previous channel content. Use only in development.')
-        parser.add_argument('--publish', action='store_true',         help='Publish newly uploaded version of the channel')
-        parser.add_argument('--sample', type=int, metavar='SIZE',     help='Upload a sample of SIZE content nodes from the channel')
+                                                                      help='Immediately deploy changes to channel\'s main tree. This operation will overwrite the previous channel content. Use only during development.')
+        parser.add_argument('--publish', action='store_true',         help='Publish newly uploaded version of the channel.')
+        parser.add_argument('--sample', type=int, metavar='SIZE',     help='Upload a sample of SIZE nodes from the channel.')
+        parser.add_argument('--reset', dest="reset_deprecated", action='store_true',
+                                                                      help='(deprecated) Restarting the chef run is the default.')
+        parser.add_argument('--stage', dest='stage_deprecated', action='store_true',
+                                                                      help='(deprecated) Stage updated content for review. Uploading a staging tree is now the default behavior. Use --deploy to upload to the main tree.')
 
         # [OPTIONS] --- extra key=value options are supported, but do not appear in help
         self.arg_parser = parser
@@ -349,9 +349,9 @@ class SushiChef(BaseChef):
             add_help=add_parser_help,
             parents=[self.arg_parser]
         )
-        self.arg_parser.add_argument('--daemon', action='store_true', help='Run chef in daemon mode')
-        self.arg_parser.add_argument('--nomonitor', action='store_true', help='Disable SushiBar progress monitoring')
-        self.arg_parser.add_argument('--cmdsock', help='Local command socket (for cronjobs)')
+        self.arg_parser.add_argument('--daemon', action='store_true', help='Run chef in daemon mode lisenting to commands.')
+        self.arg_parser.add_argument('--nomonitor', action='store_true', help='Disable SushiBar progress monitoring.')
+        self.arg_parser.add_argument('--cmdsock', help='Local command socket (for cronjobs).')
         # self.arg_parser.add_argument('--sushibar', help='Hostname of SushiBar server (e.g. "sushibar.learningequality.org")')
         # TODO: --bartoken
 

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -138,8 +138,6 @@ class BaseChef(object):
 
         if args['command'] == 'dryrun':
             args['nomonitor'] = True    # no Sushibar logs and progress tracking
-            if not args['resume']:
-                args['reset'] = True    # set the --reset flag to avoid prompt
 
         # Parse additional keyword arguments from `options_list`
         options = {}

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -42,7 +42,7 @@ def uploadchannel_wrapper(chef, args, options):
             config.SUSHI_BAR_CLIENT.close()
 
 
-def uploadchannel(chef, command='uploadchannel', update=False, thumbnails=False, download_attempts=3, resume=False, reset=False, step=Status.LAST.name, token="#", prompt=False, publish=False, compress=False, stage=False, **kwargs):
+def uploadchannel(chef, command='uploadchannel', update=False, thumbnails=False, download_attempts=3, resume=False, step=Status.LAST.name, token="#", prompt=False, publish=False, compress=False, stage=False, **kwargs):
     """ uploadchannel: Upload channel to Kolibri Studio server
         Args:
             chef (BaseChef or subclass): class that implements the construct_channel method
@@ -89,7 +89,7 @@ def uploadchannel(chef, command='uploadchannel', update=False, thumbnails=False,
 
     # Set up progress tracker
     config.PROGRESS_MANAGER = RestoreManager()
-    if (reset or not config.PROGRESS_MANAGER.check_for_session()) and step.upper() != Status.DONE.name:
+    if (not resume or not config.PROGRESS_MANAGER.check_for_session()) and step.upper() != Status.DONE.name:
         config.PROGRESS_MANAGER.init_session()
     else:
         if resume or prompt_yes_or_no('Previous session detected. Would you like to resume your last session?'):

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -52,7 +52,6 @@ def uploadchannel(chef, command='uploadchannel', update=False, thumbnails=False,
             download_attempts (int): number of times to retry downloading files (optional)
             resume (bool): indicates whether to resume last session automatically (optional)
             step (str): step to resume process from (optional)
-            reset (bool): indicates whether to start session from beginning automatically (optional)
             token (str): content server authorization token
             prompt (bool): indicates whether to prompt user to open channel when done (optional)
             publish (bool): indicates whether to automatically publish channel (optional)

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -14,7 +14,7 @@ from ricecooker.chefs import BaseChef
 FAKE_CHEF_SCRIPT = 'chefs/fake_chef.py'
 
 
-OLD_DOCOP_SPEC = """Usage: ricecooker uploadchannel [-huv] <file_path> [--warn] [--stage] [--compress] [--token=<t>] [--thumbnails] [--download-attempts=<n>] [--resume [--step=<step>] | --reset] [--prompt] [--publish] [[OPTIONS] ...]
+OLD_DOCOP_SPEC = """Usage: ricecooker uploadchannel [-huv] <file_path> [--warn] [--stage] [--compress] [--token=<t>] [--thumbnails] [--download-attempts=<n>] [--resume [--step=<step>]] [--prompt] [--publish] [[OPTIONS] ...]
 
 Arguments:
   file_path        Path to file with channel data
@@ -29,9 +29,8 @@ Options:
   --thumbnails                Automatically generate thumbnails for topics
   --token=<t>                 Authorization token (can be token or path to file with token) [default: #]
   --download-attempts=<n>     Maximum number of times to retry downloading files [default: 3]
-  --resume                    Resume from ricecooker step (cannot be used with --reset flag)
+  --resume                    Resume from ricecooker step.
   --step=<step>               Step to resume progress from (must be used with --resume flag) [default: LAST]
-  --reset                     Restart session, overwriting previous session (cannot be used with --resume flag)
   --prompt                    Receive prompt to open the channel once it's uploaded
   --publish                   Automatically publish channel once it's been created
   [OPTIONS]                   Extra arguments to add to command line (e.g. key='field')
@@ -60,7 +59,7 @@ def fake_chef_path():
 def command_line_inputs(fake_chef_path):
     test_input_templates = [
       'ricecooker uploadchannel {} --token=letoken --resume --step=START_UPLOAD',
-      'ricecooker uploadchannel {} --token=letoken --reset somethin=else extrakey=extraval',
+      'ricecooker uploadchannel {} --token=letoken somethin=else extrakey=extraval',
       'ricecooker uploadchannel -uv {} --warn --compress --download-attempts=4 --token=besttokenever --resume --step=PUBLISH_CHANNEL --prompt --publish',
       'ricecooker uploadchannel {} -v --compress --token=katoken lang=en',
       'ricecooker uploadchannel {} -v --compress --token=katoken lang=en-us',


### PR DESCRIPTION
Since chefs often run unattended, it is problematic that chefs that errored out will interactively prompt about resuming. After discussions, we determined that we almost always want to reset, so this PR makes that behavior the default, and `--resume` can be used to resume the session.