### PR TITLE
Encode titles so logging doesn't throw error

### DIFF
--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -199,7 +199,7 @@ class Node(object):
             Args: indent (int): What level of indentation at which to start printing
             Returns: None
         """
-        config.LOGGER.info("{indent}{data}".format(indent="   " * indent, data=str(self)))
+        config.LOGGER.info("{indent}{data}".format(indent="   " * indent, data=str(self).encode('utf-8')))
         for child in self.children:
             child.print_tree(indent + 1)
 

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -218,7 +218,7 @@ class ChannelManager:
             count=self.node_count_dict['upload_count'],
             total=self.node_count_dict['total_count'],
             indent="   " * indent,
-            title=current_node.title,
+            title=current_node.title.encode('utf-8'),
             kind=current_node.__class__.__name__)
         )
 


### PR DESCRIPTION
When I run chefs in other languages, it sometimes throws an error on the logging statement, which then prevents those nodes from getting scraped