### PR TITLE
Ensure chefs always clean up after themselves.

### DIFF
--- a/examples/wikipedia/README.md
+++ b/examples/wikipedia/README.md
@@ -1,0 +1,11 @@
+Wikipedia example
+=================
+
+The content integration script `sushichef.py` scrapes several wikipedia pages,
+packages their contents as standalone `HTMLZipFile`s and uploads them to Studio.
+
+
+## Running the script
+
+    ./sushichef.py   --token=YOURSTUDIOTOKENHERE9139139f3a23232
+

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -1,7 +1,10 @@
 import argparse
+import atexit
 import logging
 import os
+import shutil
 import sys
+import tempfile
 from datetime import datetime
 from importlib.machinery import SourceFileLoader
 
@@ -29,6 +32,28 @@ from .utils.metadata_provider import DEFAULT_EXERCISES_INFO_FILENAME
 from .utils.tokens import get_content_curation_token
 # for JsonTreeChef chef
 # for LineCook chef
+
+
+chef_temp_dir = os.path.join(os.getcwd(), '.ricecooker-temp')
+
+
+@atexit.register
+def delete_temp_dir():
+    if os.path.exists(chef_temp_dir):
+        config.LOGGER.info("Deleting chef temp files at {}".format(chef_temp_dir))
+        shutil.rmtree(chef_temp_dir)
+
+# While in most cases a chef run will clean up after itself, make sure that if it didn't, temp files
+# from the old run are deleted so that they do not accumulate.
+delete_temp_dir()
+
+# If tempdir is set already, that means the user has explicitly chosen a location for temp storage
+if not tempfile.tempdir:
+    os.makedirs(chef_temp_dir)
+    config.LOGGER.info("Setting chef temp dir to {}".format(chef_temp_dir))
+    # Store all chef temp files in one dir to avoid issues with temp or even primary storage filling up
+    # because of failure by the chef to clean up temp files manually.
+    tempfile.tempdir = chef_temp_dir
 
 
 # SUSHI CHEF BASE CLASS (and backward compatibiliry)


### PR DESCRIPTION
This ensures any and all tempfiles that get created will be deleted either by the end of the run, or if that failed for some reason, at the beginning of the next run.