### PR TITLE
Remove dead code around compatibility_mode and unused docopt tests

### DIFF
--- a/docs/developer/design_cli.md
+++ b/docs/developer/design_cli.md
@@ -1,24 +1,24 @@
 Command line interface
 ======================
 
-This document describes logic `ricecooker` uses to parse command line arguments.
-Under normal use cases you shouldn't need modify the command line parsing, but
-you need to understand how `argparse` works if you want to add new command line
-arguments for your chef script.
+This document describes control flow used by the `ricecooker` framework, and the
+particular logic used to parse command line arguments. Under normal use cases you
+shouldn't need modify the default command line parsing, but you need to understand
+how things work in case want to customize the command line args for your chef script.
 
 
 Summary
 -------
-A sushi chef script using the new API looks like this:
+A sushi chef script like this:
 
 
     #!/usr/bin/env python
     ...
     ...
-    class MySushiChef(BaseChef):     # or SushiChef to support remote monitoring
-        def get_channel(**kwargs)` -> ChannelNode (bare channel, used just for info)
+    class MySushiChef(SushiChef):
+        def get_channel(**kwargs)` -> ChannelNode (bare channel, used just for metadata)
             ...
-        def construct_channel(**kwargs) -> ChannelNode (with populated Tree)
+        def construct_channel(**kwargs) -> ChannelNode (with populated topic tree)
             ...
     ...
     ...
@@ -31,7 +31,7 @@ Flow diagram
 ------------
 The call to `chef.main()` results in the following sequence of six calls:
 
-    MySushiChef -----extends----> BaseChef                   commands.uploadchannel
+    MySushiChef -----extends----> SushiChef                  commands.uploadchannel
     ---------------------------   -----------------------    -----------------------
                                   1. main()
                                   2. parse_args_and_options()
@@ -46,19 +46,9 @@ The call to `chef.main()` results in the following sequence of six calls:
                                                              DONE
 
 
-Changes
--------
 
-### Old `uploadchannel` API (a.k.a. compatibility mode)
-
-  - pass in chef script file as `"<file_path>"` to uploadchannel
-  - `uploadchannel` calls the function `contruct_channel` defined in the chef script
-
-
-### New `uploadchannel` API
-
-  - The chef script defines subclass of `ricecooker.chefs.SushiChef` that implement
-    the methods `get_channel` and `construct_channel`:
+  - The chef script must define a subclass of `ricecooker.chefs.SushiChef` that
+    implement the methods `get_channel` and `construct_channel`:
 
         class MySushiChef(ricecooker.chefs.SushiChef):
             def get_channel(**kwargs)` -> ChannelNode (bare channel, used just for info)
@@ -77,22 +67,23 @@ Changes
             chef = MySushiChef()
             chef.main()
 
-  - The `__init__` method of the sushi chef class configures an `argparse` parser
-    (`BaseChef` creates `self.arg_parser` and each class adds to this shared parser
-     its own command line arguments.)
+  - The `__init__` method of the sushi chef class configures an `argparse` parser.
+    The base class `SushiChef` creates `self.arg_parser` and a chef subclass can
+    adds to this shared parser its own command line arguments. This is used only
+    in vary special cases; for most cases, using the CLI `options` is sufficient.
 
-  - The `main` method of the class parses the command line arguments and calls
-    the `run` method (or the `deamon_mode` method.)
+  - The `main` method of the `SushiChef` class parses the command line arguments
+    and calls the `run` method:
 
-        class BaseChef():
+        class SushiChef():
             ...
             def main(self):
                 args, options = self.parse_args_and_options()
                 self.run(args, options)
 
-  -  The chef's `run` method calls `uploadchannel` (or `uploadchannel_wrapper`)
+  -  The chef's `run` method calls `uploadchannel`
 
-         class BaseChef():
+         class SushiChef():
              ...
              def run(self, args, options):
                  ...
@@ -114,54 +105,20 @@ Changes
      - `run`: in case you want to call `uploadchannel` yourself
 
 
-Compatibility mode
-------------------
-Calling ricecooker as a module (`python -m ricecooker uploadchannel oldchef.py ...`)
-will run the following code in `ricecooker.__main__.py`:
-
-    from ricecooker.chefs import BaseChef
-    if __name__ == '__main__':
-        chef = BaseChef(compatibility_mode=True)
-        chef.main()
-
-The `BaseChef` class with `compatibility_mode=True` proxies call to its `construct_channel`
-method to the function `construct_channel` in `oldchef.py`.
-The call to `chef.main()` results in the following sequence of events:
-
-    oldchef.py                    BaseChef(compat mode)      commands.uploadchannel
-    ---------------------------   -----------------------    -----------------------
-                                  1. main()
-                                  2. parse_args_and_options()
-                                  3. run(args, options)
-                                                             4. uploadchannel(chef, *args, **options)
-                                                             ...
-                                                             ...
-                                  5. construct_channel(**kwargs)
-    5'. construct_channel(**kwargs)
-                                                             ...
-                                                             ...
-                                                             DONE
-
-Logging and progress reporting to SushiBar server is not supported in compatibility mode.
-
-
 
 Args, options, and kwargs
 -------------------------
 There are three types of arguments involved in a chef run:
 
   - `args` (dict): command line args as parsed by the sushi chef class and its parents
-    - BaseChef: the method ` BaseChef.__init__` configures argparse for the following:
+    - SushiChef: the method ` SushiChef.__init__` configures argparse for the following:
         - `compress`, `download_attempts`, `prompt`, `publish`, `resume`,
           `stage`, `step`, `thumbnails`, `token`, `update`, `verbose`, `warn`
-        - in compatibility mode, also handles `uploadchannel` and `chef_script` positional arguments
-    - SushiChef:
-        - `daemon` = Runs in daemon mode
-        - `nomonitor` = Disable SushiBar progress monitoring
+        - also `daemon` for runs in daemon mode, and `nomonitor` to disable SushiBar progress monitoring
     - MySushiChef: the chef's `__init__` method can define additional cli args
 
   - `options` (dict): additional [OPTIONS...] passed at the end of the command line
-    - used for compatibility mode with old ricecooker API  (`python -m ricecooker uploadchannel ...  key=value`)
+    - often used to pass the language option (`./sushichef.py ... lang=fr`)
 
   - `kwargs` (dict): chef-specific keyword arguments not handled by ricecooker's `uploadchannel` method
       - the chef's `run` method makes the call `uploadchannel(self, **args.__dict__, **options)`
@@ -170,7 +127,6 @@ There are three types of arguments involved in a chef run:
         explicitly expected by the `uploadchannel` function
       - The function `uploadchannel` will pass `**kwargs` on to the `chef`'s
         `get_channel` and `construct_channel` methods as part of the chef run.
-
 
 
 Daemon mode
@@ -190,7 +146,3 @@ Then the handler  `ControlWebSocket.on_message` will start a new run:
 
 After finishing the run, a chef started with the `--daemon` option remains connected
 to the SushiBar server and listens for more commands.
-
-
-
-

--- a/docs/developer/design_cli.md
+++ b/docs/developer/design_cli.md
@@ -111,7 +111,7 @@ Args, options, and kwargs
 There are three types of arguments involved in a chef run:
 
   - `args` (dict): command line args as parsed by the sushi chef class and its parents
-    - SushiChef: the method ` SushiChef.__init__` configures argparse for the following:
+    - SushiChef: the `SushiChef.__init__` method configures argparse for the following:
         - `compress`, `download_attempts`, `prompt`, `publish`, `resume`,
           `stage`, `step`, `thumbnails`, `token`, `update`, `verbose`, `warn`
         - also `daemon` for runs in daemon mode, and `nomonitor` to disable SushiBar progress monitoring

--- a/ricecooker/__main__.py
+++ b/ricecooker/__main__.py
@@ -1,9 +1,0 @@
-from ricecooker.chefs import BaseChef
-
-if __name__ == '__main__':
-    """
-    Entry point used when starting a sushichef using the ricecooker as a module:
-        python -m ricecooker uploadchannel --token=<studio-access-token>
-    """
-    chef = BaseChef(compatibility_mode=True)
-    chef.main()

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -58,7 +58,7 @@ class SushiChef(object):
         else:
             add_parser_help = True
         parser = argparse.ArgumentParser(
-            description="Chef scripts upload content to the Kolibri Studio server.",
+            description="Chef script for uploading content to Kolibri Studio.",
             add_help=add_parser_help,
         )
         self.arg_parser = parser  # save as class attr. for subclasses to extend
@@ -202,9 +202,9 @@ class SushiChef(object):
 
     def get_channel(self, **kwargs):
         """
-        This method create an empty `ChannelNode` object with info from the chef
-        class' `channel_info` class attribute. Subclass can ovveride this method
-        in cases where channel metadata is determined based on `kwargs`.
+        This method creates an empty `ChannelNode` object based on info from the
+        chef class' `channel_info` attribute. A subclass can ovveride this method
+        in cases where channel metadata is dynamic and depends on `kwargs`.
         Args:
             kwargs (dict): additional keyword arguments given to `uploadchannel`
         Returns: an empty `ChannelNode` that contains all the channel metadata

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -4,12 +4,10 @@ import logging
 import os
 import sys
 from datetime import datetime
-from importlib.machinery import SourceFileLoader
 
 from . import config
 from .classes.nodes import ChannelNode
 from .commands import authenticate_user
-from .commands import uploadchannel
 from .commands import uploadchannel_wrapper
 from .exceptions import InvalidUsageException
 from .exceptions import raise_for_invalid_channel
@@ -33,36 +31,39 @@ from .utils.tokens import get_content_curation_token
 
 
 
-# SUSHI CHEF BASE CLASS (and backward compatibiliry)
+# SUSHI CHEF BASE CLASS
 ################################################################################
 
-class BaseChef(object):
+class SushiChef(object):
     """
-    The base class that parses command line arguments for sushichef scripts.
-    Sushi chef sctipts call the `main` method as the entry point, which in turn
-    calls the `run` method to performs all the work (see `uploadchannel`).
-
-    This class also provides backward compaibility with old chef scripts.
-    When invoking the a sushi chef script using the old API: \
-        python -m ricecooker uploadchannel chef_script.py --token=123 ...
-    an instance of this class with `compatibility_mode = True` will be created.
-    Calling `BaseChef.run` will call the function `construct_channel` in `chef_module`.
+    This is the base class that all content integration scripts should subclass.
+    Sushi chef scripts call the `main` method as the entry point, which in turn
+    calls the `run` method to do the work (see `uploadchannel` in `commands.py`).
     """
+    CHEF_RUN_DATA = config.CHEF_DATA_DEFAULT  # loaded from chefdata/chef_data.json
+    TREES_DATA_DIR = config.TREES_DATA_DIR    # tree archives and JsonTreeChef inputs
 
-    def __init__(self, *args, compatibility_mode=False, **kwargs):
-        """
-        Setup argparse arguments.
-        """
-        self.compatibility_mode = compatibility_mode
 
-        # argparse setup
+    def __init__(self, *args, **kwargs):
+        """
+        The SushiChef initialization concerns maintly parsing command line args.
+        Overrride this method in your sushi chef class to add custom arguments.
+        """
+
+        # ARGPARSE SETUP
+        # We don't want to add argparse help if subclass has an __init__ method
+        subclasses = self.__class__.__mro__[:-2]     # all subclasses after this
+        if any(['__init__' in c.__dict__.keys() for c in subclasses]):
+            add_parser_help = False    # assume subclass' __init__ will add help
+        else:
+            add_parser_help = True
         parser = argparse.ArgumentParser(
-            description="Ricecooker puts your content in the conten server.",
-            add_help=(self.__class__ == BaseChef)  # only add help if not subclassed
+            description="Chef scripts upload content to the Kolibri Studio server.",
+            add_help=add_parser_help,
         )
+        self.arg_parser = parser  # save as class attr. for subclasses to extend
+        # ARGS
         parser.add_argument('command', nargs='?', default='uploadchannel', help='Desired action: dryrun or uploadchannel (default).')
-        if self.compatibility_mode:
-            parser.add_argument('chef_script', help='Path to chef script file')
         parser.add_argument('--token', default='#',                   help='Studio API Access Token (specify wither the token value or the path of a file that contains the token).')
         parser.add_argument('-u', '--update', action='store_true',    help='Force file re-download (skip .ricecookerfilecache/).')
         parser.add_argument('--debug', action='store_true',           help='Print extra debugging infomation.')
@@ -84,9 +85,12 @@ class BaseChef(object):
                                                                       help='(deprecated) Restarting the chef run is the default.')
         parser.add_argument('--stage', dest='stage_deprecated', action='store_true',
                                                                       help='(deprecated) Stage updated content for review. Uploading a staging tree is now the default behavior. Use --deploy to upload to the main tree.')
-
+        parser.add_argument('--daemon', action='store_true', help='Run chef in daemon mode lisenting to commands.')
+        parser.add_argument('--nomonitor', action='store_true', help='Disable SushiBar progress monitoring.')
+        parser.add_argument('--cmdsock', help='Local command socket (for cronjobs).')
         # [OPTIONS] --- extra key=value options are supported, but do not appear in help
-        self.arg_parser = parser
+
+        self.load_chef_data()
 
 
     def parse_args_and_options(self):
@@ -114,7 +118,6 @@ class BaseChef(object):
             # a key=value options pair was incorrectly recognized as the command
             args['command'] = 'uploadchannel'
             options_list.append(command_arg)  # put command_arg where it belongs
-
 
         # Print CLI deprecation warnings info
         if args['stage_deprecated']:
@@ -151,15 +154,8 @@ class BaseChef(object):
                 msg = "Invalid option '{0}': use [key]=[value] format (no whitespace)".format(preoption)
                 raise InvalidUsageException(msg)
 
-        # For compatibility mode, we check the chef script file exists and load it
-        if self.compatibility_mode:
-            try:
-                # Try to load the chef_script as a module
-                self.chef_module = SourceFileLoader("mod", args['chef_script']).load_module()
-            except FileNotFoundError as e:
-                raise InvalidUsageException('Error: must specify `chef_module` for compatibility_mode')
-
         return args, options
+
 
     def config_logger(self, args, options):
         """
@@ -204,65 +200,17 @@ class BaseChef(object):
             config.LOGGER.warning('Unable to use remote logging due to: %s' % e)
 
 
-    def pre_run(self, args, options):
-        """
-        This function is called before the Chef's `run` mehod is called.
-        By default this function does nothing, but subclass can use this hook to
-        run prerequisite tasks.
-        Args:
-            args (dict): chef command line arguments
-            options (dict): extra key=value options given on command line
-        """
-        pass
-
-
-    def run(self, args, options):
-        """
-        This function calls uploadchannel which performs all the run steps:
-          - Create ChannelNode
-          - Pupulate Tree with TopicNodes, ContentNodes, and associated File objects
-          - .
-          - ..
-          - ...
-
-        Args:
-            args (dict): ricecooker command line arguments
-            options (dict): extra key=value options given on command line
-        """
-        self.pre_run(args, options)
-        args_and_options = args.copy()
-        args_and_options.update(options)
-        uploadchannel(self, **args_and_options)
-
-
     def get_channel(self, **kwargs):
         """
-        Call chef script's get_channel method in compatibility mode
-        ...or...
-        Create a `ChannelNode` from the Chef's `channel_info` class attribute.
-
+        This method create an empty `ChannelNode` object with info from the chef
+        class' `channel_info` class attribute. Subclass can ovveride this method
+        in cases where channel metadata is determined based on `kwargs`.
         Args:
-            kwargs (dict): additional keyword arguments that `uploadchannel` received
-        Returns: channel created from get_channel method or None
+            kwargs (dict): additional keyword arguments given to `uploadchannel`
+        Returns: an empty `ChannelNode` that contains all the channel metadata
         """
-        if self.compatibility_mode:
-            # For pre-sushibar scritps that do not implement `get_channel`,
-            # we must check it this function exists before calling it...
-            if hasattr(self.chef_module, 'get_channel'):
-                config.LOGGER.info("Calling get_channel... ")
-                # Create channel (using the function in the chef script)
-                channel = self.chef_module.get_channel(**kwargs)
-            # For chefs with a `create_channel` method instead of `get_channel`
-            if hasattr(self.chef_module, 'create_channel'):
-                config.LOGGER.info("Calling create_channel... ")
-                # Create channel (using the function in the chef script)
-                channel = self.chef_module.create_channel(**kwargs)
-            else:
-                channel = None  # since no channel info, SushiBar functionality will be disabled...
-            return channel
-
-        elif hasattr(self, 'channel_info'):
-            # Before going any further, make sure there aren't template id values in channel_info
+        if hasattr(self, 'channel_info'):
+            # Make sure we're not using the template id values in `channel_info`
             template_domains = ['<yourdomain.org>']
             using_template_domain = self.channel_info['CHANNEL_SOURCE_DOMAIN'] in template_domains
             if using_template_domain:
@@ -276,7 +224,7 @@ class BaseChef(object):
             if using_template_domain or using_template_source_id:
                sys.exit(1)
 
-            # If a sublass has an `channel_info` attribute (a dict) it doesn't need
+            # If a sublass has an `channel_info` attribute (dict) it doesn't need
             # to define a `get_channel` method and instead rely on this code:
             channel = ChannelNode(
                 source_domain=self.channel_info['CHANNEL_SOURCE_DOMAIN'],
@@ -288,78 +236,18 @@ class BaseChef(object):
                 description=self.channel_info.get('CHANNEL_DESCRIPTION'),
             )
             return channel
-
         else:
-            raise NotImplementedError('BaseChef must overrride the get_channel method')
+            raise NotImplementedError('Subclass must define get_channel method or have a channel_info (dict) attribute.')
 
 
     def construct_channel(self, **kwargs):
         """
-        Calls chef script's construct_channel method. Used only in compatibility mode.
+        This should be overriden by the chef script's construct_channel method.
         Args:
-            kwargs (dict): additional keyword arguments that `uploadchannel` received
-        Returns: channel populated from construct_channel method
+            kwargs (dict): additional keyword arguments given to `uploadchannel`
+        Returns: a `ChannelNode` object representing the populated topic tree
         """
-        if self.compatibility_mode:
-            # Constuct channel (using function from imported chef script)
-            config.LOGGER.info("Populating channel... ")
-            channel = self.chef_module.construct_channel(**kwargs)
-            return channel
-        else:
-            raise NotImplementedError('Your chef class must overrride the construct_channel method')
-
-
-    def main(self):
-        args, options = self.parse_args_and_options()
-        self.config_logger(args, options)
-        self.run(args, options)
-
-
-
-
-
-# THE DEFAULT SUSHI CHEF
-################################################################################
-
-class SushiChef(BaseChef):
-    """
-    This is the main class that all suchi chefs should subclass. This class uses
-    remote logging, remote stage and progress reporting, and remote commands.
-    The `SushiChef` class a subclass of the `BaseChef` and supports the same
-    command line arguments, additionally handles arguments for Sushi Bar server.
-    Sushi chef scripts call the `main` method as the entry point, which in turn
-    calls the `run` method to performs all the work (see `uploadchannel`).
-    """
-    CHEF_RUN_DATA = config.CHEF_DATA_DEFAULT  # loaded from chefdata/chef_data.json
-    TREES_DATA_DIR = config.TREES_DATA_DIR    # tree archives and JsonTreeChef inputs
-
-
-    def __init__(self, *args, **kwargs):
-        """
-        The SushiChef supports all the command line args of a BaseChef and more.
-        Overrride this method in your sushi chef class to add custom arguments.
-        """
-        super(SushiChef, self).__init__(*args, **kwargs)
-
-        # We don't want to add argparse help if subclass has an __init__ method
-        subclasses = self.__class__.__mro__[:-3]     # all subclasses after this
-        if any(['__init__' in c.__dict__.keys() for c in subclasses]):
-            add_parser_help = False    # assume subclass' __init__ will add help
-        else:
-            add_parser_help = True
-
-        self.arg_parser = argparse.ArgumentParser(
-            description="Chef scripts upload content to the Kolibri Studio server.",
-            add_help=add_parser_help,
-            parents=[self.arg_parser]
-        )
-        self.arg_parser.add_argument('--daemon', action='store_true', help='Run chef in daemon mode lisenting to commands.')
-        self.arg_parser.add_argument('--nomonitor', action='store_true', help='Disable SushiBar progress monitoring.')
-        self.arg_parser.add_argument('--cmdsock', help='Local command socket (for cronjobs).')
-        # self.arg_parser.add_argument('--sushibar', help='Hostname of SushiBar server (e.g. "sushibar.learningequality.org")')
-        # TODO: --bartoken
-
-        self.load_chef_data()
+        raise NotImplementedError('Chef subclass must implement this method')
 
 
     def daemon_mode(self, args, options):
@@ -377,9 +265,11 @@ class SushiChef(BaseChef):
             lcs.join()
         cws.join()
 
+
     def load_chef_data(self):
         if os.path.exists(config.DATA_PATH):
             self.CHEF_RUN_DATA = json.load(open(config.DATA_PATH))
+
 
     def save_channel_tree_as_json(self, channel):
         filename = os.path.join(self.TREES_DATA_DIR, '{}.json'.format(self.CHEF_RUN_DATA['current_run']))
@@ -389,8 +279,22 @@ class SushiChef(BaseChef):
         self.CHEF_RUN_DATA['tree_archives']['current'] = filename.replace(os.getcwd() + '/', '')
         self.save_chef_data()
 
+
     def save_chef_data(self):
         json.dump(self.CHEF_RUN_DATA, open(config.DATA_PATH, 'w'), indent=2)
+
+
+    def pre_run(self, args, options):
+        """
+        This function is called before the Chef's `run` mehod is called.
+        By default this function does nothing, but subclass can use this hook to
+        run prerequisite tasks.
+        Args:
+            args (dict): chef command line arguments
+            options (dict): extra key=value options given on command line
+        """
+        pass
+
 
     def run(self, args, options):
         """
@@ -407,16 +311,22 @@ class SushiChef(BaseChef):
         self.CHEF_RUN_DATA['current_run'] = run_id
         self.CHEF_RUN_DATA['runs'].append({'id': run_id})
 
+        # TODO(Kevin): move self.download_content() call here
         self.pre_run(args, options)
         uploadchannel_wrapper(self, args, options)
 
+
     def main(self):
+        """
+        Main entry point that content integration scripts should call.
+        """
         args, options = self.parse_args_and_options()
         self.config_logger(args, options)
         if args['daemon']:
             self.daemon_mode(args, options)
         else:
             self.run(args, options)
+
 
 
 

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -42,9 +42,9 @@ def uploadchannel_wrapper(chef, args, options):
 
 
 def uploadchannel(chef, command='uploadchannel', update=False, thumbnails=False, download_attempts=3, resume=False, step=Status.LAST.name, token="#", prompt=False, publish=False, compress=False, stage=False, **kwargs):
-    """ uploadchannel: Upload channel to Kolibri Studio server
+    """ uploadchannel: Upload channel to Kolibri Studio
         Args:
-            chef (BaseChef or subclass): class that implements the construct_channel method
+            chef (SushiChef subclass): class that implements the construct_channel method
             command (str): the action we want to perform in this run
             update (bool): indicates whether to re-download files (optional)
             thumbnails (bool): indicates whether to automatically derive thumbnails from content (optional)

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -42,7 +42,7 @@ def setup_logging(level=logging.INFO, main_log=None, error_log=None, add_loggers
     Set up logging, useful to call from your sushi chef main script
 
     :param level: Minimum default level for all loggers and handlers
-    :param main_log: Main log (typically added in chefs.BaseChef)
+    :param main_log: Main log (typically added in chefs.SushiChef)
     :param error_log: Name of file to log (append) errors in
     :param add_loggers: An iterable of other loggers to configure (['scrapy'])
     """
@@ -127,7 +127,7 @@ def setup_logging(level=logging.INFO, main_log=None, error_log=None, add_loggers
 
 
 # Setup default logging. This is required so we have a basic logging setup until
-# prope user-confgured logging is configured in `BaseChef.config_logger`.
+# prope user-confgured logging is configured in `SushiChef.config_logger`.
 setup_logging()
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ with open('docs/history.rst') as history_file:
 requirements = [
     "pytest>=3.0.2",
     "requests>=2.11.1",
-    "docopt>=0.6.2",
     "le_utils>=0.1.24",
     "validators",
     "requests_file",

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,176 +1,105 @@
-import argparse
-import os
 import pytest
 import sys
-import unittest
 
-from docopt import docopt
 from mock import patch
 
 from ricecooker.exceptions import InvalidUsageException
-from ricecooker.managers.progress import Status
-from ricecooker.chefs import BaseChef
+from ricecooker.chefs import SushiChef
 
-FAKE_CHEF_SCRIPT = 'chefs/fake_chef.py'
-
-
-OLD_DOCOP_SPEC = """Usage: ricecooker uploadchannel [-huv] <file_path> [--warn] [--stage] [--compress] [--token=<t>] [--thumbnails] [--download-attempts=<n>] [--resume [--step=<step>]] [--prompt] [--publish] [[OPTIONS] ...]
-
-Arguments:
-  file_path        Path to file with channel data
-
-Options:
-  -h                          Help documentation
-  -v                          Verbose mode
-  -u                          Re-download files from file paths
-  --warn                      Print out warnings to stderr
-  --stage                     Stage updates rather than deploying them for manual verification on Kolibri Studio
-  --compress                  Compress high resolution videos to low resolution videos
-  --thumbnails                Automatically generate thumbnails for topics
-  --token=<t>                 Authorization token (can be token or path to file with token) [default: #]
-  --download-attempts=<n>     Maximum number of times to retry downloading files [default: 3]
-  --resume                    Resume from ricecooker step.
-  --step=<step>               Step to resume progress from (must be used with --resume flag) [default: LAST]
-  --prompt                    Receive prompt to open the channel once it's uploaded
-  --publish                   Automatically publish channel once it's been created
-  [OPTIONS]                   Extra arguments to add to command line (e.g. key='field')
-
-Steps (for restoring session):
-  LAST (default):       Resume where the session left off
-  INIT:                 Resume at beginning of session
-  CONSTRUCT_CHANNEL:    Resume with call to construct channel
-  CREATE_TREE:          Resume at set tree relationships
-  DOWNLOAD_FILES:       Resume at beginning of download process
-  GET_FILE_DIFF:        Resume at call to get file diff from Kolibri Studio
-  START_UPLOAD:         Resume at beginning of uploading files to Kolibri Studio
-  UPLOADING_FILES:      Resume at last upload request
-  UPLOAD_CHANNEL:       Resume at beginning of uploading tree to Kolibri Studio
-  PUBLISH_CHANNEL:      Resume at option to publish channel
-  DONE:                 Resume at prompt to open channel
-
-"""
 
 @pytest.fixture
-def fake_chef_path():
-    testsdir = os.path.dirname(__file__)
-    return os.path.join(testsdir, FAKE_CHEF_SCRIPT)
-
-@pytest.fixture
-def command_line_inputs(fake_chef_path):
-    test_input_templates = [
-      'ricecooker uploadchannel {} --token=letoken --resume --step=START_UPLOAD',
-      'ricecooker uploadchannel {} --token=letoken somethin=else extrakey=extraval',
-      'ricecooker uploadchannel -uv {} --warn --compress --download-attempts=4 --token=besttokenever --resume --step=PUBLISH_CHANNEL --prompt --publish',
-      'ricecooker uploadchannel {} -v --compress --token=katoken lang=en',
-      'ricecooker uploadchannel {} -v --compress --token=katoken lang=en-us',
-      'ricecooker uploadchannel {} -v --compress --token=katoken lang=fr-ca',
-      'ricecooker uploadchannel {} -u --compress --token=katoken lang=en-us',
+def cli_args_and_expected():
+    defaults = {
+        'command': 'uploadchannel',
+        'update': False,
+        'verbose': True, 'debug': False, 'warn': False, 'quiet': False,
+        'compress': False,
+        'thumbnails': False,
+        'download_attempts': 3,
+        'resume': False, 'step': 'LAST', 'prompt': False, 'reset_deprecated': False,
+        'stage': True, 'stage_deprecated': False,
+        'publish': False,
+        'sample': None,
+        'nomonitor': False, 'daemon': False, 'cmdsock': None,
+    }
+    return [
+        {   # this used to be the old recommended CLI args to run chefs
+            'cli_input': './sushichef.py -v --reset --token=letoken',
+            'expected_args': dict(defaults, token='letoken', reset_deprecated=True),
+            'expected_options': {},
+        },
+        {   # nowadays we've changed the CLI defaults so don't need to specify these
+            'cli_input': './sushichef.py --token=letoken',
+            'expected_args': dict(defaults, token='letoken'),
+            'expected_options': {},
+        },
+        {
+            'cli_input': './sushichef.py --token=letoken --resume --step=START_UPLOAD',
+            'expected_args': dict(defaults, token='letoken', resume=True, step='START_UPLOAD'),
+            'expected_options': {},
+        },
+        {
+            'cli_input': './sushichef.py --token=letoken lang=fr',
+            'expected_args': dict(defaults, token='letoken'),
+            'expected_options': dict(lang='fr')
+        },
+        {
+            'cli_input': './sushichef.py --token=letoken somethin=else extrakey=extraval',
+            'expected_args': dict(defaults, token='letoken'),
+            'expected_options': dict(somethin='else', extrakey='extraval')
+        },
+        {
+            'cli_input': './sushichef.py -uv --warn --compress --download-attempts=4 --token=besttokenever --resume --step=PUBLISH_CHANNEL --prompt --deploy --publish',
+            'expected_args': dict(defaults,
+                                          update=True,
+                                             warn=True, compress=True,
+                                                               download_attempts=4,  token='besttokenever', resume=True, step='PUBLISH_CHANNEL',
+                                                                                                                                            prompt=True, stage=False, publish=True),
+            'expected_options': {}
+        },
     ]
-    test_inputs = [cmdt.format(fake_chef_path) for cmdt in test_input_templates]
-    return test_inputs
 
-def old_arguments_parser(cli_input):
+
+def chef_arg_parser(cli_input):
     """
-    Takes a string `cli_input` and parses it using the `docopt` module.
-    Returns tuple of docopt arguments and extra kwargs (now called options).
-    """
-    test_argv = cli_input.split(' ')
-    with patch.object(sys, 'argv', test_argv):
-        arguments = docopt(OLD_DOCOP_SPEC)
-    assert arguments is not None, 'doc opt parsing failed'
-
-    # Parse OPTIONS for keyword arguments
-    kwargs = {}
-    for arg in arguments['OPTIONS']:
-      try:
-        kwarg = arg.split('=')
-        kwargs.update({kwarg[0].strip(): kwarg[1].strip()})
-      except IndexError:
-        raise InvalidUsageException("Invalid kwarg '{0}' found: Must format as [key]=[value] (no whitespace)".format(arg))
-
-    # Check if step is valid (if provided)
-    step = arguments['--step']
-    all_steps = [s.name for s in Status]
-    if step.upper() not in all_steps:
-      raise InvalidUsageException("Invalid step '{0}': Valid steps are {1}".format(step, all_steps))
-    arguments['--step'] = step
-
-    # Make sure max-retries can be cast as an integer
-    try:
-      int(arguments['--download-attempts'])
-    except ValueError:
-      raise InvalidUsageException("Invalid argument: Download-attempts must be an integer.")
-
-    return arguments, kwargs
-
-
-def arguments_to_args_renames(arguments):
-    """
-    The doc-opt parsed arguments include the - and -- and certain names are different.
-    In order to have an apples-to-apples comparison with the new argparse approach,
-    we must rename some of the keys.
-    """
-    args = {}
-    for k, v in arguments.items():
-        if k == '--download-attempts':
-            args['download_attempts'] = int(v)
-        elif k == '-u':
-            args['update'] = v
-        elif k == '-v':
-            args['verbose'] = True # Should default to true
-        elif k == '<file_path>':
-            args['chef_script'] = v
-        elif k == '-h':
-            pass
-        else:
-            args[k.lstrip('-')] = v
-    return args
-
-
-def new_arg_parser(cli_input):
-    """
-    Takes a string `cli_input` and parses it using the BaseChef arg_parser.
+    Takes a string `cli_input` and parses it using the SushiChef arg parser.
     Returns tuple of args and options.
     """
     test_argv = cli_input.split(' ')
     with patch.object(sys, 'argv', test_argv):
-        chef = BaseChef(compatibility_mode=True)
+        chef = SushiChef()
         args, options = chef.parse_args_and_options()
     assert args is not None, 'argparse parsing failed'
     return args, options
-
-def dict_compare(d1, d2):
-    """
-    Compare two dicts. Usage: added, removed, modified, same = dict_compare(d1, d2)
-    """
-    d1_keys = set(d1.keys())
-    d2_keys = set(d2.keys())
-    intersect_keys = d1_keys.intersection(d2_keys)
-    added = d1_keys - d2_keys
-    removed = d2_keys - d1_keys
-    modified = {o : (d1[o], d2[o]) for o in intersect_keys if d1[o] != d2[o]}
-    same = set(o for o in intersect_keys if d1[o] == d2[o])
-    return added, removed, modified, same
-
 
 
 
 """ *********** CLI ARGUMENTS TESTS *********** """
 
-@pytest.mark.skip('Deprecated test that check backward compatibility with docop')
-def test_same_as_docopt(command_line_inputs):
-    for line in command_line_inputs:
-        arguments, kwargs = old_arguments_parser(line)
-        orig_args = arguments_to_args_renames(arguments)
-        del orig_args['uploadchannel']
-        del orig_args['OPTIONS']
+def test_basic_command_line_args_and_options(cli_args_and_expected):
+    for case in cli_args_and_expected:
+        cli_input = case['cli_input']
+        expected_args = case['expected_args']
+        expected_options = case['expected_options']
 
-        args, options = new_arg_parser(line)
-        del args['command']
-        del args['quiet']  # new logging option was not present in docopt parser
-        del args['debug']  # new logging option was not present in docopt parser
+        args, options = chef_arg_parser(cli_input)
 
-        added, removed, modified, same = dict_compare(orig_args, args)
-        # print('different', added, removed, modified)
-        assert orig_args == args, 'docopt arguments differ from argparse args'
-        assert kwargs == options, 'extra key=value options differ'
+        # print('observed', args, options)
+        # print('expected', expected_args, expected_options)
+
+        for arg, val in expected_args.items():
+            assert args[arg] == val
+        for opt, val in expected_options.items():
+            assert options[opt] == val
+
+
+def test_cannot_publish_without_deploy():
+    bad_cli_input = './sushichef.py --token=letoken --publish'
+    with pytest.raises(InvalidUsageException):
+        args, options = chef_arg_parser(bad_cli_input)
+
+    good_cli_input = './sushichef.py --token=letoken --deploy --publish'
+    args, options = chef_arg_parser(good_cli_input)
+    assert args['stage'] == False
+    assert args['publish'] == True
+


### PR DESCRIPTION
 - The `SushiChef` class is now the only one you need (contain combined functionality that was previously split between `BaseChef` and `SushiChef`
 - Re-enabled tests around CLI args and options