### PR TITLE
[WIP] Add command line tool for creating and running sushi chefs.

### DIFF
--- a/ricecooker/cli.py
+++ b/ricecooker/cli.py
@@ -80,6 +80,9 @@ def run_ricecooker(cmd, remote_name=None, extra_args=None):
             else:
                 token = prompt_for_token(remote_name)
             cmd_args.extend(['--token', token])
+        else:
+            print("ERROR: No remote with name {} found. To see available remotes, run: jiro remote list")
+            sys.exit(1)
 
     print("Running {}".format(cmd_args))
     return subprocess.call(cmd_args, env=env)
@@ -107,6 +110,18 @@ def add_remote(args, remainder):
         'token': args.token
     }
     save_config()
+
+
+def list_remotes(args, remainder):
+    """
+    Create a named alias for a remote server to upload to. If none are specified, will use the default server.
+    :param args: Object containing .name and .url arguments.
+    :return:
+    """
+
+    global jiro_config
+    for remote in jiro_config['remotes']:
+        print("{}: {}".format(remote, jiro_config['remotes'][remote]['url']))
 
 
 def set(args, remainder):
@@ -197,11 +212,17 @@ def main():
     set_cmd.add_argument('value', nargs='?', help='Value as string to set property to.')
     set_cmd.set_defaults(func=set)
 
-    add_cmd = commands.add_parser('add-remote')
+    remote_cmd = commands.add_parser('remote')
+    remote_cmds = remote_cmd.add_subparsers(title='remotes', description='Commands related to remote server management.')
+
+    add_cmd = remote_cmds.add_parser('add')
     add_cmd.add_argument('name', nargs='?', help='Name of upload server.')
     add_cmd.add_argument('url', nargs='?', help='URL of server to upload to.')
     add_cmd.add_argument('token', nargs='?', help='User authentication token for server.')
     add_cmd.set_defaults(func=add_remote)
+
+    list_cmd = remote_cmds.add_parser('list')
+    list_cmd.set_defaults(func=list_remotes)
 
     setup_cmd = commands.add_parser('setup')
     setup_cmd.set_defaults(func=setup_env)

--- a/ricecooker/cli.py
+++ b/ricecooker/cli.py
@@ -1,0 +1,225 @@
+import argparse
+import os
+import re
+import subprocess
+import sys
+import uuid
+
+CONFIG_DIR = os.path.join(os.path.expanduser('~'), '.ricecooker')
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'config.yaml')
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_DIR = os.path.join(SCRIPT_DIR, 'templates')
+
+import ricecooker
+import ricecooker.config as config
+
+from jinja2 import Template
+import yaml
+
+props = ['token', 'tempdir']
+jiro_config = {}
+if os.path.exists(CONFIG_FILE):
+    jiro_config = yaml.full_load(open(CONFIG_FILE))
+
+
+def save_config():
+    global jiro_config
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    yaml.dump(jiro_config, open(CONFIG_FILE, 'w'))
+
+
+def get_chef_script():
+    if os.path.exists('chef.py'):
+        return 'chef.py'
+
+    return 'sushichef.py'
+
+
+def prompt_for_token(remote_name):
+    global jiro_config
+    print("remote_name = {}".format(remote_name))
+    remote = jiro_config['remotes'][remote_name]
+    result = input("Please enter an authentication token for server {} ({}): ".format(remote_name, remote['url']))
+    remote['token'] = result
+    save_config()
+
+    return result
+
+
+def run_ricecooker(cmd, remote_name=None, extra_args=None):
+    """
+    Runs ricecooker. Should be run from a directory containing sushichef.py or chef.py.
+    :param args: Object with passed parameters and default values.
+    :return:
+    """
+    global jiro_config
+
+    cmd_args = [
+        sys.executable,
+        get_chef_script(),
+        cmd
+    ]
+
+    cmd_args.extend(extra_args)
+
+    env = os.environ.copy()
+
+    if 'tempdir' in jiro_config:
+        env['TMPDIR'] = jiro_config['tempdir'].format(CHEFDIR=os.getcwd())
+        print("TMPDIR = {}".format(env['TMPDIR']))
+
+    token = None
+
+    if remote_name:
+        if remote_name in jiro_config['remotes']:
+            remote = jiro_config['remotes'][remote_name]
+            env['STUDIO_URL'] = remote['url']
+            if 'token' in remote and remote['token']:
+                token = remote['token']
+            else:
+                token = prompt_for_token(remote_name)
+            cmd_args.extend(['--token', token])
+
+    print("Running {}".format(cmd_args))
+    return subprocess.call(cmd_args, env=env)
+
+
+def add_default_remote():
+    global jiro_config
+    if not 'remotes' in jiro_config:
+        jiro_config['remotes'] = {'default': {'url': config.DEFAULT_DOMAIN}}
+
+    # Note: we won't prompt for token until trying to upload to remote.
+    save_config()
+
+
+def add_remote(args, remainder):
+    """
+    Create a named alias for a remote server to upload to. If none are specified, will use the default server.
+    :param args: Object containing .name and .url arguments.
+    :return:
+    """
+
+    global jiro_config
+    jiro_config['remotes'][args.name] = {
+        'url': args.url,
+        'token': args.token
+    }
+    save_config()
+
+
+def set(args, remainder):
+    """
+    Sets a key / value pair in the config file.
+    :param args: Object that contains .name and .value properties
+    :return:
+    """
+    global jiro_config
+    jiro_config[args.name] = args.value
+    save_config()
+
+
+def new_chef(args, remainder):
+
+    name = args.name
+    repo_name = "sushi-chef-{}".format(name.lower().replace(" ", "-"))
+
+    # strip out non-alphanumeric charactesr from class name
+    chef_name = re.sub('[^A-Za-z0-9]+', '', name.title())
+
+    arg_dict = {
+        'channel_id': uuid.uuid4().hex,
+        'channel_name': name,
+        'chef_name': chef_name
+    }
+
+    cwd = os.getcwd()
+    repo_dir = os.path.join(cwd, repo_name)
+
+    # If we've already created teh repo dir and are in it, then don't create a subdir with the same name.
+    if repo_name in cwd:
+        repo_dir = cwd
+
+    os.makedirs(repo_dir, exist_ok=True)
+
+    os.chdir(repo_dir)
+    assets_dir = os.path.join(repo_dir, 'assets')
+    os.makedirs(assets_dir, exist_ok=True)
+    chef_filename = os.path.join(repo_dir, 'sushichef.py')
+    if not os.path.exists(chef_filename):
+        template = Template(open(os.path.join(TEMPLATE_DIR, 'sushichef.py')).read())
+        output = template.render(**arg_dict)
+        f = open(chef_filename, 'w')
+        f.write(output)
+        f.close()
+
+    reqs_filename = os.path.join(repo_dir, 'requirements.txt')
+    if not os.path.exists(reqs_filename):
+        f = open(reqs_filename, 'w')
+        f.write("ricecooker>={}".format(ricecooker.__version__))
+        f.close()
+
+
+def setup_env(args, remainder):
+    cwd = os.getcwd()
+    venv_dir = os.path.join(cwd, '.venv')
+    if not os.path.exists(venv_dir):
+        subprocess.call(['virtualenv', venv_dir])
+
+    requirements = os.path.join(cwd, 'requirements.txt')
+    assert os.path.exists(requirements), "No requirements.txt file found, cannot set up Python environment."
+    subprocess.call(['pip', 'install', '-r', 'requirements.txt'])
+
+
+def fetch(args, remainder):
+    return run_ricecooker('fetch', extra_args=remainder)
+
+
+def prepare(args, remainder):
+    return run_ricecooker('dryrun', extra_args=remainder)
+
+
+def serve(args, remainder):
+    return run_ricecooker('uploadchannel', args.destination, extra_args=remainder)
+
+
+def main():
+    # ensure we always have the default remote set.
+    add_default_remote()
+
+    parser = argparse.ArgumentParser()
+
+    commands = parser.add_subparsers(title='commands', help='Commands to operate on ricecooker projects')
+
+    set_cmd = commands.add_parser('set')
+    set_cmd.add_argument('name', nargs='?', help='Property to set. Choices are: %r' % (props,))
+    set_cmd.add_argument('value', nargs='?', help='Value as string to set property to.')
+    set_cmd.set_defaults(func=set)
+
+    add_cmd = commands.add_parser('add-remote')
+    add_cmd.add_argument('name', nargs='?', help='Name of upload server.')
+    add_cmd.add_argument('url', nargs='?', help='URL of server to upload to.')
+    add_cmd.add_argument('token', nargs='?', help='User authentication token for server.')
+    add_cmd.set_defaults(func=add_remote)
+
+    setup_cmd = commands.add_parser('setup')
+    setup_cmd.set_defaults(func=setup_env)
+
+    new_cmd = commands.add_parser('new')
+    new_cmd.add_argument('name', nargs='?', help='Name of new chef')
+    new_cmd.set_defaults(func=new_chef)
+
+    fetch_cmd = commands.add_parser('fetch')
+    fetch_cmd.set_defaults(func=fetch)
+
+    prepare_cmd = commands.add_parser('prepare')
+    prepare_cmd.set_defaults(func=prepare)
+
+    serve_cmd = commands.add_parser('serve')
+    serve_cmd.add_argument('destination', nargs='?', default="default", help='Name of remote server to upload to.')
+    serve_cmd.set_defaults(func=serve)
+
+    # just pass down the remaining args to the command.
+    args, unknown = parser.parse_known_args()
+    sys.exit(args.func(args, unknown))

--- a/ricecooker/templates/sushichef.py
+++ b/ricecooker/templates/sushichef.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import os
+import sys
+from ricecooker.utils import downloader, html_writer
+from ricecooker.chefs import SushiChef
+from ricecooker.classes import nodes, files, questions, licenses
+from ricecooker.config import LOGGER              # Use LOGGER to print messages
+from ricecooker.exceptions import raise_for_invalid_channel
+from le_utils.constants import exercises, content_kinds, file_formats, format_presets, languages
+
+
+# Run constants
+################################################################################
+CHANNEL_ID = "{{channel_id}}"             # UUID of channel
+CHANNEL_NAME = "{{channel_name}}"                           # Name of Kolibri channel
+CHANNEL_SOURCE_ID = "<yourid>"                              # Unique ID for content source
+CHANNEL_DOMAIN = "<yourdomain.org>"                         # Who is providing the content
+CHANNEL_LANGUAGE = "en"                                     # Language of channel
+CHANNEL_DESCRIPTION = None                                  # Description of the channel (optional)
+CHANNEL_THUMBNAIL = None                                    # Local path or url to image file (optional)
+CONTENT_ARCHIVE_VERSION = 1                                 # Increment this whenever you update downloaded content
+
+
+# Additional constants
+################################################################################
+
+
+
+# The chef subclass
+################################################################################
+class {{chef_name}}Chef(SushiChef):
+    """
+    This class converts content from the content source into the format required by Kolibri,
+    then uploads the {channel_name} channel to Kolibri Studio.
+    Your command line script should call the `main` method as the entry point,
+    which performs the following steps:
+      - Parse command line arguments and options (run `./sushichef.py -h` for details)
+      - Call the `SushiChef.run` method which in turn calls `pre_run` (optional)
+        and then the ricecooker function `uploadchannel` which in turn calls this
+        class' `get_channel` method to get channel info, then `construct_channel`
+        to build the contentnode tree.
+    For more info, see https://ricecooker.readthedocs.io
+    """
+    channel_info = {
+        'CHANNEL_ID': CHANNEL_ID,
+        'CHANNEL_SOURCE_DOMAIN': CHANNEL_DOMAIN,
+        'CHANNEL_SOURCE_ID': CHANNEL_SOURCE_ID,
+        'CHANNEL_TITLE': CHANNEL_NAME,
+        'CHANNEL_LANGUAGE': CHANNEL_LANGUAGE,
+        'CHANNEL_THUMBNAIL': CHANNEL_THUMBNAIL,
+        'CHANNEL_DESCRIPTION': CHANNEL_DESCRIPTION,
+    }
+    DATA_DIR = os.path.abspath('chefdata')
+    DOWNLOADS_DIR = os.path.join(DATA_DIR, 'downloads')
+    ARCHIVE_DIR = os.path.join(DOWNLOADS_DIR, 'archive_{}'.format(CONTENT_ARCHIVE_VERSION))
+
+    # Your chef subclass can override/extend the following method:
+    # get_channel: to create ChannelNode manually instead of using channel_info
+    # pre_run: to perform preliminary tasks, e.g., crawling and scraping website
+    # __init__: if need to customize functionality or add command line arguments
+    def construct_channel(self, *args, **kwargs):
+        """
+        Creates ChannelNode and build topic tree
+        Args:
+          - args: arguments passed in on the command line
+          - kwargs: extra options passed in as key="value" pairs on the command line
+            For example, add the command line option   lang="fr"  and the value
+            "fr" will be passed along to `construct_channel` as kwargs['lang'].
+        Returns: ChannelNode
+        """
+        channel = self.get_channel(*args, **kwargs)  # Create ChannelNode from data in self.channel_info
+
+        # TODO: Replace next line with chef code
+        raise NotImplementedError("constuct_channel method not implemented yet...")
+
+        return channel
+
+
+
+# CLI
+################################################################################
+if __name__ == '__main__':
+    # This code runs when sushichef.py is called from the command line
+    chef = {{chef_name}}Chef()
+    chef.main()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('docs/history.rst') as history_file:
 requirements = [
     "pytest>=3.0.2",
     "requests>=2.11.1",
-    "le_utils>=0.1.24",
+    "le_utils>=0.1.26",
     "validators",                             # TODO: check if this is necessary
     "requests_file",
     "beautifulsoup4>=4.6.3,<4.9.0",   # pinned to match versions in le-pycaption
@@ -30,6 +30,8 @@ requirements = [
     "dictdiffer>=0.8.0",
     "Pillow==5.4.1",
     "colorlog>=4.1.0,<4.2",
+    "PyYAML>=5.3.1",
+    "Jinja2>=2.10"
 ]
 
 test_requirements = [
@@ -50,6 +52,7 @@ setup(
     entry_points = {
         'console_scripts': [
             'corrections = ricecooker.utils.corrections:correctionsmain',
+            'jiro = ricecooker.cli:main'
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
Jiro is a command line interface to ricecooker that creates an interface wrapper around common operations related to ricecooker-based scripts. Specifically:

* It has a `jiro new <chef-name>` command that creates a new project dir and adds a template `sushichef.py` and `requirements.txt` file.
* `jiro add-remote <remote-alias> <url> [token]` lets you add aliased Studio instances to push changes to. If you don't specify a token, you will be prompted for one during first push.
* `jiro prepare [options]` runs `sushchef.py`, but does not upload the results. `[options]` are any ricecooker-supported command line arguments.
* `jiro serve <remote-alias> [options]` runs `sushichef.py` and uploads the result to the remote specified by `remote-alias`. If a remote is not specified, it defaults to `studio.learningequality.org`. `[options]` are any ricecooker-supported command line arguments.
