### PR TITLE
Docs: Fixing syntax in PDF splitting example

### DIFF
--- a/docs/pdfutils.md
+++ b/docs/pdfutils.md
@@ -44,7 +44,7 @@ them in a `TopicNode` that corresponds to the book:
     for chapter in chapters:
         chapter_node = nodes.DocumentNode(
             title=chapter['title'],
-            files=files.DocumentFile(chapter['path']),
+            files=[files.DocumentFile(chapter['path'])],
             ...
         )
         book_node.add_child(chapter_node)


### PR DESCRIPTION
An additional pair of brackets is required around the `DocumentNode(...)`, otherwise `TypeError: 'DocumentFile' object is not iterable` will be thrown.