### PR TITLE
Docs: Remove mentions of deprecated flags

### DIFF
--- a/docs/developer/uploadprocess.md
+++ b/docs/developer/uploadprocess.md
@@ -142,9 +142,6 @@ to activate the "draft copy" and make it visible to all Studio users.
 This is implemented by replacing the channel's `main` tree with the `staging` tree.
 During [this step](https://github.com/learningequality/studio/blob/5564c1fc540d8a936fc2907c9d65bf0fb2bacb14/contentcuration/contentcuration/api.py#L103-L105), a "backup copy" of channel is saved, called the `previous_tree`.
 
-Running the chef script with the `--deploy` flag will have this effect.
-Do not use this for production channels: always DEPLOY on Studio after reviewing what changed.
-
 
 Publish channel (optional)
 --------------------------
@@ -156,10 +153,6 @@ This step is a prerequisite for getting the channel out of Studio and into Kolib
 The combination of `{{channel_id}}.sqlite3` file and the files in `/content/storage`
 define the Kolibri Channels content format. This is what gets exported to the folder
 `KOLIBRI_DATA` on sdcard or external drives when you use the `EXPORT` action in Kolibri.
-
-Running the chef scrip with the args `--deploy --publish` will perform the `DEPLOY`
-and `PUBLISH` actions after the chef run completes. This is not recommended for
-any channel other than small testing channels and for debugging.
 
 
 

--- a/docs/tutorial/explanations.md
+++ b/docs/tutorial/explanations.md
@@ -185,9 +185,7 @@ uploaded to "draft version" of the channel called a "`staging` tree".
 The purpose of the staging tree is to allow channel editors can to review the
 changes in the "draft version" as compared to the current version of the channel.
 Use the **DEPLOY** button in the Studio web interface to activate the "draft copy"
-and make it visible to all Studio users. Running the chef script with the `--deploy`
-flag will perform this step automatically at the end of the chef run.
-
+and make it visible to all Studio users.
 
 
 Publishing the channel
@@ -197,12 +195,6 @@ The **PUBLISH** action exports all the channel metadata to a sqlite3 DB file ser
 by Studio at the URL `/content/{{channel_id}}.sqlite3` and ensure the associated
 files exist in `/content/storage/` which is served by a CDN.
 This step is a prerequisite for getting the channel out of Studio and into Kolibri.
-Running the chef scrip with the args `--deploy --publish` will perform both
-the **DEPLOY** and **PUBLISH** actions after the chef run completes.
-This combination of arguments can be used for testing and debugging, and never
-for "production" channels, which should be deployed only after reviewing what changed.
-
-
 
 
 Next steps


### PR DESCRIPTION
Remove mention of `--deploy` and `--publish` flags - Per discussion with Kevin, these are deprecated.