### PR TITLE
Support creation of page-relative links in ArchiveDownloader, and make it default

### DIFF
--- a/docs/downloader.md
+++ b/docs/downloader.md
@@ -1,8 +1,91 @@
 Downloading web content
 =======================
+
+### The ArchiveDownloader class
+
+**New in 0.7**
+
+#### Overview
+The `ArchiveDownloader` class encapsulates the functionality of
+downloading URLs, their related resources, and rewriting page links
+to point to their downloaded location.
+
+All the downloaded content becomes part of an archive, which can be
+saved and reused on future runs of the script. After the download completes,
+the script could even be run offline.
+
+This enables many things, including the ability to update and re-run scripts even
+if the original content was removed, easily and automatically create a dependency
+zip of content shared by various pages in the archive, and create HTML5 zips for
+pages that correctly include all necessary resources without extra code.
+
+#### Using ArchiveDownloader
+
+`ArchiveDownloader` has the following general workflow:
+
+- Create an `ArchiveDownloader` instance before downloading any web content.
+- Call `get_page` on that instance passing in full URLs to pages you wish to download.
+- Once content has been downloaded, you need to create an HTML5 zip of the content.
+  * If the content does not need to be modified, call `export_page_as_zip` and use the
+    zip created as a file for an HTML5 app node.
+  * If you need to make modifications, call `create_zip_dir_for_page`, then modify
+    the files in the directory it returns as needed. (Not modifying the original
+     sources allows you to keep a clean copy at all times.) Finally, create a ZIP by
+    calling `ricecooker.utils.create_predictable_zip` and use the zip created
+    as a file for an HTML5 app node.
+
+Usage example:
+
+```python
+    from ricecooker.utils.downloader import ArchiveDownloader
+
+    sushi_url = 'https://en.wikipedia.org/wiki/Sushi'
+
+    archive = ArchiveDownloader("downloads/archive_1")
+    # Download and store page in the archive
+    archive.get_page(sushi_url)
+    # Convert page into a Kolibri-friendly HTML5 zip file
+    zip_file = archive.export_page_as_zip(sushi_url)
+    # ... code to add zip_file to an HTML5AppNode ...
+```
+
+Example scripts:
+
+The [COVID 19 Simulations sushi chef](https://github.com/learningequality/sushi-chef-covid19-sim/blob/master/sushichef.py)
+ provides a relatively small and simple example of how to use `ArchiveDownloader`.
+
+#### Using `get_page`
+
+By default, `get_page` will download the page and all its related resources, including
+CSS, image, and JS files. You can also pass a few optional arguments to modify its
+behavior:
+
+`refresh` [True | False]:
+If `True`, this will re-download the page, even if it is already in the archive.
+
+`run_js` [True | False]:
+If `True`, the page will be loaded using `pyppeteer` and wait until page load handlers
+have run before downloading the content. If `False` (default), it will use `requests`
+to download the content.
+
+`link_policy` [Dict or None]:
+Defines how to handle scraping of page links. The default, `None`, indicates no scraping.
+If a dictionary is passed, it may contain the following keys:
+
+* `levels` [Integer]: (Required) Number of levels deep to scrape links.
+* `scope` [String]: (Optional) Defaults to "internal", which only scrapes links on the
+same domain. Change to "all" to scrape links from external domains as well.
+* `whitelist` [List]: (Optional) A list of strings containing URLs to be whitelisted.
+They will be compared against complete URLs, so the strings can be as complete as desired.
+e.g. `www.mydomain.com/subdir/subdir2/` can be used to match against only URLs in that
+particular subdir.
+* `blacklist` [List]: (Optional) A list of strings containing URLs to be blacklisted.
+URLs can be specified using the same rules as the `whitelist` argument.
+
+### downloader.py Functions
+
 The Ricecooker module `utils/downloader.py` provides a `read` function that can
 be used to read the file contents from both urls and local file paths.
-
 
 Usage examples:
 

--- a/docs/index_utils.rst
+++ b/docs/index_utils.rst
@@ -1,7 +1,7 @@
-Ricecooker utils
+Working with content
 ================
-The ``ricecooker.utils`` module includes a number of utility functions to help
-chef authors with common content extraction and transformation tasks.
+Ricecooker includes a number of utility functions to help chef authors
+with common content extraction and transformation tasks.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -6,5 +6,6 @@ These purpose of these pages is to help you learn the ``ricecooker`` framework.
    :maxdepth: 2
 
    gettingstarted
+   jiro
    tutorial
    explanations

--- a/docs/tutorial/jiro.md
+++ b/docs/tutorial/jiro.md
@@ -1,0 +1,58 @@
+The jiro command line tool
+==========================
+
+**New in 0.7**
+
+Named after the master sushi chef, the `jiro` command line tool
+provides a command line interface around sushi chef scripts and
+simplifies common tasks when operating on sushi chef scripts.
+
+It has the following commands:
+
+#### jiro new
+
+`jiro new [script name]`
+
+Create a new sushi-chef script. Will create a `sushi-chef-[name]`
+directory unless the command is run within a directory of that name.
+
+#### jiro remote
+
+Used to manage Studio server upload authentication.
+
+`jiro remote add [remote-name] [url] <token>`
+
+Registers a new Studio instance to upload to.
+
+* `remote-name` is a short string used to refer to this server in `jiro` commands.
+* `URL` should be the fully qualified URL to the root of a Studio server
+* `token` - if specified, the token to use to authenticate to the server. If not
+  specified, you will be prompted to provide the token before your first upload.
+
+`jiro remote list`
+
+List the Studio servers you have registered with `jiro`.
+
+#### jiro prepare
+
+`jiro prepare`
+
+This command should be run in the root script directory containing `sushichef.py`.
+
+Downloads content and creates the channel tree, but skips the upload step. Often
+used while iterating on scripts.
+
+#### jiro serve
+
+`jiro serve <remote-name>`
+
+This command should be run in the root script directory containing `sushichef.py`.
+
+Runs the same steps as `jiro prepare`, but also uploads the results to Studio.
+If `remote-name` is specified, it will upload to the remote server registered
+with that name. Otherwise, it will upload to production Studio.
+
+If you have never registered an API token for the Studio server you're uploading to,
+it may prompt you to enter it when running this command.
+
+

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -44,3 +44,11 @@ class TestArchiver(unittest.TestCase):
 
         assert result == 'learningequality.org/kolibri_v_1.2.3_i_u.png'
         assert urls_to_replace[link] == 'learningequality.org/kolibri_v_1.2.3_i_u.png'
+
+    def test_archive_path_as_relative_url(self):
+        link = '../kolibri.png?1.2.3'
+        page_link = 'https://learningequality.org/team/index.html'
+        page_filename = downloader.get_archive_filename(page_link, download_root='./')
+        link_filename = downloader.get_archive_filename(link, page_url=page_link, download_root='./')
+        rel_path = downloader.get_relative_url_for_archive_filename(link_filename, page_filename)
+        assert rel_path == '../kolibri_1.2.3.png'

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -29,3 +29,35 @@ def test_replace_absolute_links():
 
     output = replace_links(img_srcset_content, urls_to_replace)
     assert output == '<img srcset="img/hello.jpg 1x, img/hello.jpg 2x">'
+
+
+def test_replace_relative_links():
+    a_content = '<a href="http://replace.me/link/to/page.html">'
+    noscheme_a_content = '<a href="//replace.me/link/to/page.html">'
+    root_a_content = '<a href="/link/to/page.html">'
+
+    img_content = '<img src="http://replace.me/img/hello.jpg">'
+
+    img_srcset_content = '<img srcset="http://replace.me/img/hello.jpg 1x, http://replace.me/img/hello.jpg 2x">'
+
+    urls_to_replace = {
+        'http://replace.me/img/hello.jpg': 'replace.me/img/hello.jpg',
+        'http://replace.me/link/to/page.html': 'replace.me/link/to/page.html'
+    }
+    content_dir = 'replace.me/link/from'
+    download_root = '.'
+
+    output = replace_links(img_content, urls_to_replace, download_root=download_root, content_dir=content_dir, relative_links=True)
+    assert output == '<img src="../../img/hello.jpg">'
+
+    output = replace_links(a_content, urls_to_replace, download_root=download_root, content_dir=content_dir, relative_links=True)
+    assert output == '<a href="../to/page.html">'
+
+    output = replace_links(noscheme_a_content, urls_to_replace, download_root=download_root, content_dir=content_dir, relative_links=True)
+    assert output == '<a href="../to/page.html">'
+
+    output = replace_links(root_a_content, urls_to_replace, download_root=download_root, content_dir=content_dir, relative_links=True)
+    assert output == '<a href="../to/page.html">'
+
+    output = replace_links(img_srcset_content, urls_to_replace, download_root=download_root, content_dir=content_dir, relative_links=True)
+    assert output == '<img srcset="../../img/hello.jpg 1x, ../../img/hello.jpg 2x">'


### PR DESCRIPTION
After this change, by default `ArchiveDownloader` will always make links page-relative, no longer requiring us to re-write links from the archive when packaging them into a zip. The old behavior can be restored for now, but this should just be temporary and will not be documented since it's for compatibility with a small number of existing chefs that use the code.

Also adds docs for `ArchiveDownloader`, and the `jiro` command line tool as well.