### PR TITLE
ricecooker.utils.pdf.PDFParser#get_toc reimplemented to use pdftk

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -72,7 +72,7 @@ jobs:
         curl --output pdftk.exe https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-win-setup.exe
         7z x ffmpeg.zip -otools -y
         7z x poppler.7z -otools -y
-        pdftx.exe /extract:tools /passive /quiet
+        pdftk.exe /extract:tools /passive /quiet
     - name: Set paths to Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -44,8 +44,7 @@ jobs:
         sudo apt-get install -y ffmpeg
         sudo apt-get install -y poppler-utils
         curl --output pdftk https://gitlab.com/pdftk-java/pdftk/-/jobs/924565150/artifacts/raw/build/native-image/pdftk
-        sudo chmod +x pdftk
-        export PATH="$(pwd):$PATH"
+        sudo install pdftk /usr/bin
       if: matrix.os == 'ubuntu-latest'
     - name: Cache Mac dependencies
       uses: actions/cache@v2

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -72,7 +72,7 @@ jobs:
         curl --output pdftk.exe https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-win-setup.exe
         7z x ffmpeg.zip -otools -y
         7z x poppler.7z -otools -y
-        pdftk.exe /extract:tools /passive /quiet
+        Start-Process -Filepath "$pwd\pdftk.exe" -ArgumentList @("/extract:tools", "/passive", "/quiet")
     - name: Set paths to Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install Mac dependencies
       run: |
         brew install ffmpeg poppler
-        curl --output ./pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
+        curl --output ./pdftk.pkg https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
         installer -pkg ./pdftk.pkg -target CurrentUserHomeDirectory
       if: matrix.os == 'macos-latest'
     - name: Windows dependencies cache

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -43,7 +43,9 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get install -y ffmpeg
         sudo apt-get install -y poppler-utils
-        sudo apt-get install -y pdftk-java
+        curl --output pdftk https://gitlab.com/pdftk-java/pdftk/-/jobs/924565150/artifacts/raw/build/native-image/pdftk
+        sudo chmod +x pdftk
+        export PATH="$(pwd):$PATH"
       if: matrix.os == 'ubuntu-latest'
     - name: Cache Mac dependencies
       uses: actions/cache@v2
@@ -54,8 +56,8 @@ jobs:
     - name: Install Mac dependencies
       run: |
         brew install ffmpeg poppler
-        curl --output pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
-        installer -pkg pdftk.pkg -target CurrentUserHomeDirectory
+        curl --output ./pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
+        installer -pkg ./pdftk.pkg -target CurrentUserHomeDirectory
       if: matrix.os == 'macos-latest'
     - name: Windows dependencies cache
       id: windowscache

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -43,6 +43,7 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get install -y ffmpeg
         sudo apt-get install -y poppler-utils
+        sudo apt-get install -y pdftk-java
       if: matrix.os == 'ubuntu-latest'
     - name: Cache Mac dependencies
       uses: actions/cache@v2
@@ -51,7 +52,10 @@ jobs:
         path: ~/Library/Caches/Homebrew
         key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Install Mac dependencies
-      run: brew install ffmpeg poppler
+      run: |
+        brew install ffmpeg poppler
+        curl --output pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
+        installer -pkg pdftk.pkg -target CurrentUserHomeDirectory
       if: matrix.os == 'macos-latest'
     - name: Windows dependencies cache
       id: windowscache
@@ -65,13 +69,16 @@ jobs:
       run: |
         curl --output ffmpeg.zip https://web.archive.org/web/20200916110500if_/https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20200831-4a11a6f-win64-static.zip
         curl --output poppler.7z http://blog.alivate.com.au/wp-content/uploads/2018/10/poppler-0.68.0_x86.7z
+        curl --output pdftk.exe https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-win-setup.exe
         7z x ffmpeg.zip -otools -y
         7z x poppler.7z -otools -y
+        pdftx.exe /extract:tools /passive /quiet
     - name: Set paths to Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |
         echo "$pwd\tools\ffmpeg-20200831-4a11a6f-win64-static\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$pwd\tools\poppler-0.68.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "$pwd\tools\pdftk\bin\pdftk.exe" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Cache pip
       if: ${{ !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v2

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -54,6 +54,7 @@ jobs:
         key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Install Mac dependencies
       run: |
+        chsh -s /bin/zsh
         brew install ffmpeg poppler
         curl --output ./pdftk.pkg https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
         installer -pkg ./pdftk.pkg -target CurrentUserHomeDirectory

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -43,8 +43,8 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get install -y ffmpeg
         sudo apt-get install -y poppler-utils
-        curl --output pdftk https://gitlab.com/pdftk-java/pdftk/-/jobs/924565150/artifacts/raw/build/native-image/pdftk
-        sudo install pdftk /usr/bin
+        curl --output cpdf https://github.com/coherentgraphics/cpdf-binaries/blob/master/Linux-Intel-64bit/cpdf
+        sudo install cpdf /usr/bin
       if: matrix.os == 'ubuntu-latest'
     - name: Cache Mac dependencies
       uses: actions/cache@v2
@@ -54,10 +54,8 @@ jobs:
         key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Install Mac dependencies
       run: |
-        chsh -s /bin/zsh
         brew install ffmpeg poppler
-        curl --output ./pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
-        installer -pkg ./pdftk.pkg -target CurrentUserHomeDirectory
+        curl --output /usr/bin/cpdf https://github.com/coherentgraphics/cpdf-binaries/blob/master/OSX-Intel/cpdf
       if: matrix.os == 'macos-latest'
     - name: Windows dependencies cache
       id: windowscache
@@ -71,16 +69,16 @@ jobs:
       run: |
         curl --output ffmpeg.zip https://web.archive.org/web/20200916110500if_/https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20200831-4a11a6f-win64-static.zip
         curl --output poppler.7z http://blog.alivate.com.au/wp-content/uploads/2018/10/poppler-0.68.0_x86.7z
-        curl --output pdftk.exe https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-win-setup.exe
+        curl --output cpdf.exe https://github.com/coherentgraphics/cpdf-binaries/blob/master/Windows64bit/cpdf.exe
         7z x ffmpeg.zip -otools -y
         7z x poppler.7z -otools -y
-        Start-Process -Filepath "$pwd\pdftk.exe" -ArgumentList @("/extract:tools", "/passive", "/quiet")
+        Start-Process -Filepath "$pwd\cpdf.exe" -ArgumentList @("/extract:tools", "/passive", "/quiet")
     - name: Set paths to Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |
         echo "$pwd\tools\ffmpeg-20200831-4a11a6f-win64-static\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$pwd\tools\poppler-0.68.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "$pwd\tools\pdftk\bin\pdftk.exe" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "$pwd\tools\cpdf\bin\cpdf.exe" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Cache pip
       if: ${{ !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v2

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -72,13 +72,12 @@ jobs:
         curl --output cpdf.exe https://github.com/coherentgraphics/cpdf-binaries/blob/master/Windows64bit/cpdf.exe
         7z x ffmpeg.zip -otools -y
         7z x poppler.7z -otools -y
-        Start-Process -Filepath "$pwd\cpdf.exe" -ArgumentList @("/extract:tools", "/passive", "/quiet")
     - name: Set paths to Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |
         echo "$pwd\tools\ffmpeg-20200831-4a11a6f-win64-static\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$pwd\tools\poppler-0.68.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "$pwd\tools\cpdf\bin\cpdf.exe" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "$pwd\cpdf.exe" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Cache pip
       if: ${{ !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v2

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         chsh -s /bin/zsh
         brew install ffmpeg poppler
-        curl --output ./pdftk.pkg https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
+        curl --output ./pdftk.pgk https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg
         installer -pkg ./pdftk.pkg -target CurrentUserHomeDirectory
       if: matrix.os == 'macos-latest'
     - name: Windows dependencies cache

--- a/ricecooker/utils/pdf.py
+++ b/ricecooker/utils/pdf.py
@@ -1,36 +1,42 @@
 import os
 import subprocess
 
-from tempfile import NamedTemporaryFile
-from PyPDF2 import PdfFileWriter, PdfFileReader
-from PyPDF2.generic import Destination, NullObject
-from PyPDF2.utils import PdfReadError
+from tempfile import mkstemp
 from ricecooker.utils.downloader import read
 
 
-class CustomDestination(Destination):
-    def __init__(self, title, page, typ, *args):
-        try:
-            super(CustomDestination, self).__init__(title, page, typ, *args)
-        except PdfReadError:
-            pass
+# pdftk output keys for parsing control simplicity
+BOOKMARK_BEGIN = "BookmarkBegin"
+LAST_BOOKMARK_BEGIN = "PageMediaBegin"
+TITLE = "BookmarkTitle"
+LEVEL = "BookmarkLevel"
+PAGE_START = "BookmarkPageNumber"
+NUM_OF_PAGES = "NumberOfPages"
 
-class CustomPDFReader(PdfFileReader):
-    def _buildDestination(self, title, array):
-        page, typ = array[0:2]
-        array = array[2:]
-        return CustomDestination(title, page, typ, *array)
+
+def get_pdftk_line_value(line):
+    """
+    Returns everything right of the : in the given line. Useful for getting the value
+    for a key in pdftk dump_data* output
+    :param line:string
+    :return:string
+    """
+    # Get everything right of the : sans spaces and newlines and quotes
+    return line.split(":")[-1].strip(" \n")
 
 
 class PDFParser(object):
     """
     Helper class for extracting table of contents and splitting PDFs into chapters.
     """
-    path = None       # Local path to source PDF document that will be processed
+
+    path = None  # Local path to source PDF document that will be processed
 
     def __init__(self, source_path, directory="downloads"):
         self.directory = directory
         self.source_path = source_path
+        self.toc_subchapters = None
+        self.toc = None
 
     def __enter__(self):
         """
@@ -60,192 +66,177 @@ class PDFParser(object):
             with open(self.path, "wb") as fobj:
                 fobj.write(read(self.source_path))
 
-        self.file = open(self.path, 'rb')
-        self.pdf = CustomPDFReader(self.file)
+        self.file = open(self.path, "rb")
+        self.pdftk_dump_data = self._pdftk_dump_data()
 
     def close(self):
         """
         Close main pdf file when done.
         """
-        self.file.close() # Make sure zipfile closes no matter what
+        self.file.close()  # Make sure zipfile closes no matter what
+
+    def number_of_pages(self):
+        """
+        Returns the number of pages in the document
+        """
+        x = int(
+            get_pdftk_line_value(
+                # Find the line where the # of pages is defined
+                next(line for line in self.pdftk_dump_data if NUM_OF_PAGES in line)
+            )
+        )
+        return x
 
     def check_path(self):
         if not self.path:
             raise ValueError("self.path not found; call `open` first")
 
     def get_toc(self, subchapters=False):
-        temp_file = NamedTemporaryFile()
-        subprocess.run(["pdftk", self.file.name, "dump_data_utf8", "output", temp_file.name])
+        # This function was reimplemented in the move from PyPDF2 to pdftk for
+        # processing PDF files and extracting the bookmarks metadata.
+        # PyPDF2 was 0-indexed
+        # pdftk is 1-indexed - so you'll see some -1s going on in here to simplify
+        # the transition so that PDFParser works just as it did before
+        chapters = list()
 
-        # pdftk output keys for parsing control simplicity
-        CHAPTER_DELIMITER = "BookmarkBegin"
-        LAST_CHAPTER_DELIMITER = "PageMediaBegin"
-        TITLE = "BookmarkTitle"
-        LEVEL = "BookmarkLevel"
-        PAGE_START = "BookmarkPageNumber"
-        NUM_OF_PAGES = "NumberOfPages"
+        # Init a chapter dict with None for its values. Note: page_end isn't
+        # initialized here because it is calculated later on
+        def new_chapter():
+            return {key: None for key in [TITLE, LEVEL, PAGE_START]}
 
-        def get_line_value(_line):
-            # Get everything right of the : sans spaces and newlines and quotes
-            return _line.split(":")[-1].strip(" \n")
+        # Checks that given chapter does not have None in its values
+        def chapter_is_completed(chapter):
+            return None not in chapter.values()
 
-        # Start by parsing each of the Bookmarks from the pdftk output into a
-        # usable Python dictionary for further processing - this includes children
-        chapters = []
-        num_of_pages = None
-        chapter = None
-        for line in temp_file.readlines():
-            line = line.decode('utf-8')
+        chapter = new_chapter()
 
-            # If we're at the delimiters, we're parsing a new chapter or we're done
-            if CHAPTER_DELIMITER in line or LAST_CHAPTER_DELIMITER in line:
-                # If we have chapter and we already filled it out - cast it to dict
-                # to pass by value and not by reference to append() (shallow copy only)
-                if chapter and None not in chapter.values():
+        # The dump needs to be processed line-by-line to get chapter data
+        for idx, line in enumerate(self.pdftk_dump_data):
+            # If the line is BOOKMARK_BEGIN or LAST_BOOKMARK_BEGIN then we
+            # are about to start building a new set of chapter data.
+            if BOOKMARK_BEGIN in line or LAST_BOOKMARK_BEGIN in line:
+                if chapter_is_completed(chapter):
+                    parent_chapter = next(
+                        (
+                            c
+                            for c in reversed(chapters)
+                            if chapter[LEVEL] - c[LEVEL] == 1
+                        ),
+                        None,
+                    )
+                    if parent_chapter:
+                        chapter["parent"] = parent_chapter["id"]
+                    chapter["id"] = idx  # Used to simplify hierarchy lookups
                     chapters.append(dict(chapter))
-                # No matter what, we should leave this by initializing chapter anew
-                chapter = {key: None for key in [TITLE, LEVEL, PAGE_START]}
-                continue
+                    chapter = new_chapter()
             elif NUM_OF_PAGES in line:
-                num_of_pages = int(get_line_value(line))
+                num_of_pages = int(get_pdftk_line_value(line))
             elif TITLE in line:
-                chapter[TITLE] = get_line_value(line).replace("\xa0", " ")
+                chapter[TITLE] = get_pdftk_line_value(line).replace("\xa0", " ")
             elif LEVEL in line:
-                chapter[LEVEL] = int(get_line_value(line))
+                chapter[LEVEL] = int(get_pdftk_line_value(line))
             elif PAGE_START in line:
-                chapter[PAGE_START] = int(get_line_value(line)) - 1
+                # Accommodate with -1 change to pdftk from PyPDF2
+                chapter[PAGE_START] = int(get_pdftk_line_value(line)) - 1
 
-
-        toc = []
+        flat_chapters = list()
         for idx, chapter in enumerate(chapters):
-            if chapter[LEVEL] == 1:
-                try:
-                    # page_end is the start_page of the next chapter where it is level 1 (root node)
-                    page_end = [ch for ch in chapters[idx+1:] if ch[LEVEL] == 1][0][PAGE_START]
-                except (KeyError, IndexError):
-                    # We got the `num_of_pages` variable for this exact reason - we're at the last
-                    # chapter and it's last page is going to be this value
-                    page_end = num_of_pages
 
-                content = {
-                    'title': chapter[TITLE],
-                    'page_start': chapter[PAGE_START],
-                    'page_end': page_end
-                }
-                toc.append(content)
-            else:
+            def are_siblings(ch1, ch2):
+                # Returns whether both items are root or are children of the same parent
+                return (ch1[LEVEL] == 1 and ch2[LEVEL] == 1) or ch1.get(
+                    "parent", True
+                ) == ch2.get("parent", False)
+
+            next_chapter_of_same_level = next(
+                (c for c in list(chapters)[(idx + 1) :] if are_siblings(c, chapter)),
+                None,
+            )
+
+            # Handle potential subchapters (or skip them)
+            if chapter[LEVEL] > 1:
                 if not subchapters:
                     continue
 
-                # We want to get the next child to help us get correct page numbers
-                next_child = None
-                try:
-                    next_child = chapters[idx+1]
-                except (KeyError, IndexError):
-                    # We're not mad about it, just don't want to crash over it as
-                    # the other acceptable value for next_child is None
-                    pass
+                # Check if this is the last subchapter in a level and its page_end is its parent's page_end
+                if not next_chapter_of_same_level:
+                    # parent_chapter is the most recent chapter added to flat_chapters that is 1 level up
+                    # and if we're here it absolutely exists
+                    parent_chapter = next(
+                        (
+                            c
+                            for c in reversed(flat_chapters)
+                            if chapter[LEVEL] - c[LEVEL] == 1
+                        ),
+                        None,
+                    )
+                    chapter["page_end"] = parent_chapter["page_end"]
+                    flat_chapters.append(chapter)
+                    continue
 
-                # All items are in order - so the last in toc is the parent
-                parent = toc[-1]
+                # We're working with one of several children of the same level - the page end of this is
+                # the PAGE_START of the next_chapter_of_same_level
+                chapter["page_end"] = next_chapter_of_same_level[PAGE_START]
+                flat_chapters.append(chapter)
+            else:
+                # For non-subchapters, the process is the same
+                if not next_chapter_of_same_level:
+                    # For the last chapter the page_end is the last page of the doc
+                    chapter["page_end"] = num_of_pages
+                else:
+                    chapter["page_end"] = next_chapter_of_same_level[PAGE_START]
+                flat_chapters.append(chapter)
 
-                if "children" not in parent:
-                    parent["children"] = list()
+        # Recursively takes the chapter data we built above and converts it to the dict
+        # that this class's methods expect
+        def chapter_to_toc(chapter):
+            content = {
+                "title": chapter[TITLE],
+                "page_start": chapter[PAGE_START],
+                "page_end": chapter["page_end"],  # for now
+            }
+            if subchapters:
+                # Get this chapter's children - we'll prepare content for each of them recursively
+                children = [
+                    chapter_to_toc(c)
+                    for c in flat_chapters
+                    if c.get("parent") == chapter["id"]
+                ]
+                if len(children):
+                    content["children"] = children
+            return content
 
-                parent["children"].append(
-                    {
-                        'title': chapter[TITLE],
-                        'page_start': chapter[PAGE_START],
-                        # If there is not next_child, we're on the last item and page_end == page_start + 1
-                        # - the +1 is because `page_end` refers to the page after you end.
-                        'page_end': next_child and next_child[PAGE_START] or (chapter[PAGE_START] + 1)
-                    }
-                )
+        # Get just the root bookmark chapters - we'll use these as a starting point
+        root_chapters = [chapter for chapter in flat_chapters if chapter[LEVEL] == 1]
+        toc = list()
+        for chapter in root_chapters:
+            toc.append(chapter_to_toc(chapter))
 
-        toc[-1]['page_end'] = num_of_pages
-        temp_file.close()
         return toc
 
-    def get_old_toc(self, subchapters=False):
-        """
-        Returns table-of-contents information extracted from the PDF doc.
-        When `subchapters=False`, the output is a list of this form
-
-        .. code-block:: python
-
-            [
-                {'title': 'First chapter',  'page_start': 0,  'page_end': 10},
-                {'title': 'Second chapter', 'page_start': 10, 'page_end': 20},
-                ...
-            ]
-
-        Use the `split_chapters` method to process this list.
-        When `subchapters=True`, the output is chapter-subchapter tree structure,
-        that can be processed using the `split_subchapters` method.
-        """
-        self.check_path()
-        chapters = []
-        index = 0
-
-        for dest in self.pdf.getOutlines():
-
-            # Process chapters
-            if isinstance(dest, CustomDestination) and not isinstance(dest['/Page'], NullObject):
-                page_num = self.pdf.getDestinationPageNumber(dest)
-                chapter_pagerange = {
-                    "title": dest['/Title'].replace('\xa0', ' '),
-                    "page_start": page_num if index != 0 else 0,
-                    "page_end": self.pdf.numPages,
-                }
-                if subchapters:
-                    chapter_pagerange["children"] = []
-                chapters.append(chapter_pagerange)
-
-                if index > 0:
-                    # Go back to previous chapter and set page_end
-                    chapters[index - 1]["page_end"] = page_num
-                    if subchapters:
-                        previous_chapter = chapters[index - 1]
-                        if previous_chapter["children"]:
-                            # Go back to previous subchapter and set page_end
-                            previous_chapter["children"][-1]["page_end"] = page_num
-                index += 1
-
-            # Attach subchapters (lists) as children to last chapter
-            elif subchapters and isinstance(dest, list):
-                parent = chapters[index - 1]
-                subindex = 0
-                for subdest in dest:
-                    if isinstance(subdest, CustomDestination) and not isinstance(subdest['/Page'], NullObject):
-                        subpage_num = self.pdf.getDestinationPageNumber(subdest)
-                        parent['children'].append({
-                            "title": subdest['/Title'].replace('\xa0', ' '),
-                            "page_start": subpage_num,
-                            "page_end": self.pdf.numPages
-                        })
-                        if subindex > 0:
-                            parent['children'][subindex - 1]["page_end"] = subpage_num
-                        subindex +=1
-
-        return chapters
-
-    def write_pagerange(self, pagerange, prefix=''):
+    def write_pagerange(self, pagerange, prefix=""):
         """
         Save the subset of pages specified in `pagerange` (dict) as separate PDF.
         e.g. pagerange = {'title':'First chapter', 'page_start':0, 'page_end':5}
         """
-        writer = PdfFileWriter()
-        slug = "".join([c for c in pagerange['title'].replace(" ", "-") if c.isalnum() or c == "-"])
-        write_to_path = os.path.sep.join([self.directory, "{}{}.pdf".format(prefix, slug)])
-        for page in range(pagerange['page_start'], pagerange['page_end']):
-            writer.addPage(self.pdf.getPage(page))
-            writer.removeLinks()                   # must be done every page
-        with open(write_to_path, 'wb') as outfile:
-            writer.write(outfile)
+        slug = "".join(
+            [c for c in pagerange["title"].replace(" ", "-") if c.isalnum() or c == "-"]
+        )
+        write_to_path = os.path.sep.join(
+            [self.directory, "{}{}.pdf".format(prefix, slug)]
+        )
+        pdftk_command = "pdftk A={} cat A{}-{} output {}".format(
+            self.file.name,
+            pagerange["page_start"] + 1,
+            pagerange["page_end"],
+            write_to_path,
+        ).split(" ")
+        subprocess.run(pdftk_command)
+        print(write_to_path)
+        print(pagerange)
         return write_to_path
 
-
-    def split_chapters(self, jsondata=None, prefix=''):
+    def split_chapters(self, jsondata=None, prefix=""):
         """
         Split the PDF doc into individual chapters based on the page-range info,
         storing individual split PDFs in the output folder `self.directory`.
@@ -257,11 +248,10 @@ class PDFParser(object):
         toc = jsondata or self.get_toc()
         chapters = []
         for index, chpagerange in enumerate(toc):
-            newprefix = prefix + str(index) + '-'
+            newprefix = prefix + str(index) + "-"
             write_to_path = self.write_pagerange(chpagerange, prefix=newprefix)
-            chapters.append({"title": chpagerange['title'], "path": write_to_path})
+            chapters.append({"title": chpagerange["title"], "path": write_to_path})
         return chapters
-
 
     def split_subchapters(self, jsondata=None):
         """
@@ -277,31 +267,51 @@ class PDFParser(object):
 
         for index, chpagerange in enumerate(toc):
             # chapter prefix of the form 1-, 2-, 3-,... to avoid name conflicsts
-            chprefix = str(index) + '-'
+            chprefix = str(index) + "-"
             # Case A: chapter with no subchapters
-            if 'children' not in chpagerange or not chpagerange['children']:
+            if "children" not in chpagerange or not chpagerange["children"]:
                 write_to_path = self.write_pagerange(chpagerange, prefix=chprefix)
-                chapters.append({"title": chpagerange['title'], "path": write_to_path})
+                chapters.append({"title": chpagerange["title"], "path": write_to_path})
 
             # Case B: chapter with subchapters
-            elif 'children' in chpagerange:
-                chapter_topic = { 'title': chpagerange['title'], 'children': [] }
-                subchpageranges = chpagerange['children']
+            elif "children" in chpagerange:
+                chapter_topic = {"title": chpagerange["title"], "children": []}
+                subchpageranges = chpagerange["children"]
                 first_subchapter = subchpageranges[0]
 
                 # Handle case when chapter has "intro pages" before first subchapter
-                if first_subchapter['page_start'] > chpagerange['page_start']:
+                if first_subchapter["page_start"] - chpagerange["page_start"] > 1:
                     chintro_pagerange = {
-                        'title': chpagerange['title'],
-                        'page_start': chpagerange['page_start'],
-                        'page_end': first_subchapter['page_start']
+                        "title": chpagerange["title"],
+                        "page_start": chpagerange["page_start"],
+                        "page_end": first_subchapter["page_start"],
                     }
-                    write_to_path = self.write_pagerange(chintro_pagerange, prefix=chprefix)
-                    chapter_topic['children'].append({"title": chpagerange['title'], "path": write_to_path})
+                    write_to_path = self.write_pagerange(
+                        chintro_pagerange, prefix=chprefix
+                    )
+                    chapter_topic["children"].append(
+                        {"title": chpagerange["title"], "path": write_to_path}
+                    )
 
                 # Handle all subchapters
-                subchapter_nodes = self.split_chapters(jsondata=subchpageranges, prefix=chprefix)
-                chapter_topic['children'].extend(subchapter_nodes)
+                subchapter_nodes = self.split_chapters(
+                    jsondata=subchpageranges, prefix=chprefix
+                )
+                chapter_topic["children"].extend(subchapter_nodes)
                 chapters.append(chapter_topic)
 
         return chapters
+
+    def _pdftk_dump_data(self):
+        """
+        Runs pdftk dump_data_utf8 and puts it into tempfile. This method
+        returns the contents of that file as a list via readlines()
+        :param self:
+        :return: list of lines from the pdftk dump_data_utf8 output
+        """
+        fptr, file_path = mkstemp()
+        subprocess.run(["pdftk", self.file.name, "dump_data_utf8", "output", file_path])
+        lines = list()
+        with open(file_path) as f:
+            lines = f.readlines()
+        return lines

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ requirements = [
     "lockfile==0.12.2",                       # TODO: check if this is necessary
     "css-html-js-minify==2.2.2",
     "mock==2.0.0",
-    "pypdf2>=1.26.0",
     "dictdiffer>=0.8.0",
     "Pillow==5.4.1",
     "colorlog>=4.1.0,<4.2",

--- a/tests/test_pdfutils.py
+++ b/tests/test_pdfutils.py
@@ -24,7 +24,7 @@ def downloads_dir():
 @pytest.fixture
 def doc1_with_toc_path():
     doc1_with_toc_path = os.path.join('tests', 'testcontent', 'samples', 'sample_doc_with_toc.pdf')
-    assert os.path.exists(doc1_with_toc_path), 'Error mising test file ' + doc1_with_toc_path
+    assert os.path.exists(doc1_with_toc_path), 'Error missing test file ' + doc1_with_toc_path
     return doc1_with_toc_path
 
 def _save_file_url_to_path(url, path):

--- a/tests/test_pdfutils.py
+++ b/tests/test_pdfutils.py
@@ -6,7 +6,6 @@ import re
 import requests
 from tempfile import TemporaryDirectory
 
-from PyPDF2 import PdfFileReader
 from ricecooker.classes import nodes, files
 
 from ricecooker.utils.pdf import PDFParser                                 # SIT
@@ -160,17 +159,16 @@ def test_split_subchapters(doc1_with_toc_path, downloads_dir):
         assert _get_pdf_len(chapters[3]) == 3, 'wrong num pages in ' + str(chapters[3])
 
         ch4 = chapters[4]
-        assert 'children' in ch4, 'no children'
+        assert ('children' in ch4) == True, 'no children'
         assert len(ch4['children']) == 2
         assert _get_pdf_len(ch4['children'][0]) == 1, 'wrong num pages in ' + str(ch4['children'][0])
         assert _get_pdf_len(ch4['children'][1]) == 1, 'wrong num pages in ' + str(ch4['children'][1])
 
         ch5 = chapters[5]
-        assert 'children' in ch5, 'no children'
-        assert len(ch5['children']) == 3
+        assert ('children' in ch5) == True, 'no children'
+        assert len(ch5['children']) == 2
         assert _get_pdf_len(ch5['children'][0]) == 1, 'wrong num pages in ' + str(ch5['children'][0])
         assert _get_pdf_len(ch5['children'][1]) == 1, 'wrong num pages in ' + str(ch5['children'][1])
-        assert _get_pdf_len(ch5['children'][2]) == 1, 'wrong num pages in ' + str(ch5['children'][2])
 
 
 
@@ -209,9 +207,8 @@ def _get_pdf_len(str_or_dict_with_path_attr):
         path = str_or_dict_with_path_attr
     else:
         path = str_or_dict_with_path_attr['path']
-    with open(path, 'rb') as pdffile:
-        pdf = PdfFileReader(pdffile)
-        return pdf.numPages
+    with PDFParser(path) as pdf:
+        return pdf.number_of_pages()
 
 
 def _check_pagerange_matches_title_len(pagerange):

--- a/tests/test_pdfutils.py
+++ b/tests/test_pdfutils.py
@@ -116,7 +116,7 @@ def test_split_chapters2(doc2_with_toc_path, downloads_dir):
 
 
 def test_split_chapters3(doc3_with_toc_path, downloads_dir):
-    # print(doc3_with_toc_path)
+    print(doc3_with_toc_path)
     with PDFParser(doc3_with_toc_path, directory=downloads_dir) as pdfparser:
         chapters = pdfparser.split_chapters()
         # pprint(chapters)
@@ -208,7 +208,7 @@ def _get_pdf_len(str_or_dict_with_path_attr):
     else:
         path = str_or_dict_with_path_attr['path']
     with PDFParser(path) as pdf:
-        return pdf.number_of_pages()
+        return pdf.page_count
 
 
 def _check_pagerange_matches_title_len(pagerange):


### PR DESCRIPTION
Fixes #312 

WIP - Need to make a test that fails the old `get_toc` implementation (temporarily renamed to `get_old_toc`) but passes the new one to be sure that I'm addressing the issue noted about PDFs created with `wkhtmltopdf`.

Currently:

- Newly implemented `get_toc` passes existing test suites.
- `get_toc` uses `NamedTemporaryFile` and hopefully in a cross-OS compatible way (I only accessed it using the `.name` property once and close the file at the end anyway).
- I didn't see the need to update any other methods since the others mentioned by @rtibbles in #312 call `get_toc` for their data.