### PR TITLE
Add file metadata for questions to ensure they can be uploaded properly.

### DIFF
--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -54,6 +54,10 @@ class ChannelManager:
 
         for node_file in node.files:
             self.file_map[node_file.get_filename()] = node_file
+        if hasattr(node, "questions"):
+            for question in node.questions:
+                for question_file in question.files:
+                    self.file_map[question_file.get_filename()] = question_file
 
 
     def check_for_files_failed(self):


### PR DESCRIPTION
The recent change in file upload caused a breakage in uploading files inside assessments. This ensures that this will now work.