### PR TITLE
fix: tag length validation

### DIFF
--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -576,8 +576,8 @@ class TreeNode(Node):
         assert isinstance(self.tags, list), "Assumption Failed: Tags is not a list"
         for tag in self.tags:
             assert isinstance(tag, str), "Assumption Failed: Tag is not a string"
-            assert len(tag) <= 50, (
-                "ERROR: tag " + tag + " is too long. Tags should be 50 chars or less."
+            assert len(tag) <= 30, (
+                "ERROR: tag " + tag + " is too long. Tags should be 30 chars or less."
             )
         return super(TreeNode, self).validate()
 


### PR DESCRIPTION
This PR is in reference to https://github.com/learningequality/studio/issues/3296. The tag character length check was expecting them to be less than or equal to 50 chars but in Kolibri we enforce a 30 char limit. This PR fixes that validation. 