### PR TITLE
Do processing of all image files to ensure compliance with requirements.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = tests/
 norecursedirs = docs examples resources
+env =
+    # cleaned up in conftest.py fixture
+    RICECOOKER_STORAGE=./.pytest_storage

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ norecursedirs = docs examples resources
 env =
     # cleaned up in conftest.py fixture
     RICECOOKER_STORAGE=./.pytest_storage
+    RICECOOKER_FILECACHE=./.pytest_filecache

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
 requests-cache==0.4.13
 pytest==6.2.2
 pycountry==17.5.14
+pytest-env==0.6.2

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -146,7 +146,7 @@ def download(path, default_ext=None):
     config.LOGGER.info("\tDownloading {}".format(path))
 
     # Write file to temporary file
-    with tempfile.NamedTemporaryFile() as tempf:
+    with tempfile.NamedTemporaryFile(delete=False) as tempf:
         tempf.close()
         write_path_to_filename(path, tempf.name)
         # Get extension of file or use `default_ext` if none found
@@ -154,6 +154,7 @@ def download(path, default_ext=None):
         filename = copy_file_to_storage(tempf.name, ext=ext)
         FILECACHE.set(key, bytes(filename, "utf-8"))
         config.LOGGER.info("\t--- Downloaded {}".format(filename))
+        os.unlink(tempf.name)
 
     return filename
 

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -200,7 +200,9 @@ RESTORE_DIRECTORY = "restore"
 SESSION = requests.Session()
 
 # Cache for filenames
-FILECACHE_DIRECTORY = ".ricecookerfilecache"
+FILECACHE_DIRECTORY = os.getenv(
+    "RICECOOKER_FILECACHE", os.path.join(CURRENT_CWD, ".ricecookerfilecache")
+)
 
 FAILED_FILES = []
 

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -147,6 +147,8 @@ if DOMAIN.endswith("/"):
     DOMAIN = DOMAIN.rstrip("/")
 FILE_STORE_LOCATION = hashlib.md5(DOMAIN.encode("utf-8")).hexdigest()
 
+CURRENT_CWD = os.getcwd()
+
 # Allow users to choose which phantomjs they use
 PHANTOMJS_PATH = os.getenv("PHANTOMJS_PATH", None)
 
@@ -187,7 +189,9 @@ OPEN_CHANNEL_URL = "{domain}/channels/{channel_id}/{access}"
 PUBLISH_CHANNEL_URL = "{domain}/api/internal/publish_channel"
 
 # Folder to store downloaded files
-STORAGE_DIRECTORY = "storage"
+STORAGE_DIRECTORY = os.getenv(
+    "RICECOOKER_STORAGE", os.path.join(CURRENT_CWD, "storage")
+)
 
 # Folder to store progress tracking information
 RESTORE_DIRECTORY = "restore"
@@ -226,7 +230,7 @@ CSV_HEADERS = [
 ]
 
 # Automatic temporary direcotry cleanup
-chef_temp_dir = os.path.join(os.getcwd(), ".ricecooker-temp")
+chef_temp_dir = os.path.join(CURRENT_CWD, ".ricecooker-temp")
 
 
 @atexit.register
@@ -341,9 +345,7 @@ def get_storage_path(filename):
     Returns: string path to file
     """
     directory = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__), STORAGE_DIRECTORY, filename[0], filename[1]
-        )
+        os.path.join(STORAGE_DIRECTORY, filename[0], filename[1])
     )
     # Make storage directory for downloaded files if it doesn't already exist
     if not os.path.exists(directory):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "lockfile==0.12.2",  # TODO: check if this is necessary
     "css-html-js-minify==2.2.2",
     "mock==2.0.0",
-    "pypdf2>=1.26.0",
+    "pypdf2==1.26.0",
     "dictdiffer>=0.8.0",
     "Pillow==8.2.0",
     "colorlog>=4.1.0,<4.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,16 +52,25 @@ def pytest_sessionfinish(session, exitstatus):
 
 
 TEMP_RICECOOKER_STORAGE = "./.pytest_storage"
+TEMP_RICECOOKER_FILECACHE = "./.pytest_filecache"
 
 
 @pytest.fixture(scope="session", autouse=True)
 def global_fixture():
     if not os.path.exists(TEMP_RICECOOKER_STORAGE):
         os.mkdir(TEMP_RICECOOKER_STORAGE)
+    if not os.path.exists(TEMP_RICECOOKER_FILECACHE):
+        os.mkdir(TEMP_RICECOOKER_FILECACHE)
     yield  # wait until the test ended
     if os.path.exists(TEMP_RICECOOKER_STORAGE):
         try:
             shutil.rmtree(TEMP_RICECOOKER_STORAGE)
+        except OSError:
+            # Don't fail a test just because we failed to cleanup
+            pass
+    if os.path.exists(TEMP_RICECOOKER_FILECACHE):
+        try:
+            shutil.rmtree(TEMP_RICECOOKER_FILECACHE)
         except OSError:
             # Don't fail a test just because we failed to cleanup
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,7 +514,7 @@ def invalid_audio_file():
 
 @pytest.fixture
 def document_file():
-    source_url = "https://ia802506.us.archive.org/8/items/generalmanual_000075878/generalmanual_000075878.pdf"
+    source_url = "https://archive.org/download/manualzz-id-707752/707752.pdf"
     local_path = os.path.abspath(
         os.path.join(
             os.path.dirname(__file__), "testcontent", "downloaded", "testdocument.pdf"
@@ -528,7 +528,7 @@ def document_file():
 
 @pytest.fixture
 def document_filename():
-    return "b976c31a7ab68a97f12541d661245238.pdf"
+    return "480fe2b9d6b10d8f4fc0ab4a68d787a0.pdf"
 
 
 @pytest.fixture

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -496,19 +496,13 @@ def test_base_question_set_image(image_texts_fixtures):
         # check 3
         image_file = images[0]
         filename = image_file.get_filename()
-        assert datum["hash"] in filename, "wront content hash for file"
+        assert datum["hash"] in filename, "wrong content hash for file"
         # print('filename=', filename)
         if text.startswith("web+graphie:"):
             assert new_text.startswith("web+graphie:"), "web+graphie: was lost"
             assert filename.endswith(".graphie"), "wrong extension for web+graphie text"
         expected_storage_dir = os.path.join(STORAGE_DIRECTORY, filename[0], filename[1])
-        expected_storage_path = os.path.abspath(
-            os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
-                "ricecooker",
-                os.path.join(expected_storage_dir, filename),
-            )
-        )
+        expected_storage_path = os.path.join(expected_storage_dir, filename)
         assert os.path.exists(
             expected_storage_path
         ), "Image file not saved to ricecooker storage dir"

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -42,9 +42,6 @@ def test_youtube_video_cache(youtube_video_cache):
             os.path.dirname(__file__), "testcontent", "youtubecache", "test-video.json"
         )
     )
-    cache_dir = os.path.abspath(  # noqa F841
-        os.path.join(os.path.dirname(__file__), "testcontent", "youtubecache")
-    )
     assert video_info and os.path.exists(video_cache_filepath)
 
 


### PR DESCRIPTION
Until now images that are embedded into assessment item questions, answers, or hints, would not be processed/coerced into compatible image formats, so then would fail to be uploaded.

This moves the logic from thumbnail images that does this to be more widely accessible, so that all images get properly processed into compatible PNG formats (if for example they were Webp).

This PR also adds logic for validating SVG files, and also does some cleanup/consolidation of file copying and filename generation logic. The principle change here is to avoid passing around open file handles for copy operations, which result in files becoming corrupted when copy operations are repeated.