### PR TITLE
Add file duration at upload

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -387,6 +387,7 @@ class File(object):
     language = None
     assessment_item = None
     is_primary = False
+    duration = None
 
     def __init__(self, preset=None, language=None, default_ext=None, source_url=None):
         self.preset = preset
@@ -462,6 +463,7 @@ class File(object):
                     "original_filename": self.original_filename,
                     "language": self.language,
                     "source_url": self.source_url,
+                    "duration": self.duration,
                 }
             else:
                 config.LOGGER.warning(
@@ -604,7 +606,6 @@ class AudioFile(DownloadFile):
     default_ext = file_formats.MP3
     allowed_formats = [file_formats.MP3]
     is_primary = True
-    duration = None
 
     def get_preset(self):
         return self.preset or format_presets.AUDIO
@@ -669,7 +670,6 @@ class VideoFile(DownloadFile):
     default_ext = file_formats.MP4
     allowed_formats = [file_formats.MP4, file_formats.WEBM]
     is_primary = True
-    duration = None
 
     def __init__(self, path, ffmpeg_settings=None, **kwargs):
         self.ffmpeg_settings = ffmpeg_settings
@@ -761,7 +761,6 @@ class VideoFile(DownloadFile):
 
 class WebVideoFile(File):
     is_primary = True
-    duration = None
     # In future, look into postprocessors and progress_hooks
 
     def __init__(

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -473,7 +473,7 @@ class TreeNode(Node):
         self.provider = provider or ""
         self.tags = tags or []
         self.domain_ns = domain_ns
-        self.duration = kwargs.get("duration") or None
+        self.suggested_duration = kwargs.get("suggested_duration") or None
         self.questions = (
             self.questions if hasattr(self, "questions") else []
         )  # Needed for to_dict method
@@ -822,7 +822,7 @@ class ContentNode(TreeNode):
             "questions": [question.to_dict() for question in self.questions],
             "extra_fields": json.dumps(self.extra_fields),
             "role": self.role,
-            "duration": self.duration,
+            "suggested_duration": self.suggested_duration,
             "grade_levels": self.grade_levels,
             "resource_types": self.resource_types,
             "learning_activities": self.learning_activities,
@@ -898,10 +898,6 @@ class VideoNode(ContentNode):
                 if isinstance(f, VideoFile) or isinstance(f, WebVideoFile)
             ), "Assumption Failed: Video node should have at least one video file"
 
-            video_files = [f for f in self.files if isinstance(f, VideoFile)]
-            if video_files:
-                self.duration = video_files[0].duration
-
             # Ensure that there is only one subtitle file per language code
             new_files = []
             language_codes_seen = set()
@@ -967,9 +963,6 @@ class AudioNode(ContentNode):
         from .files import AudioFile
 
         try:
-            audio_files = [f for f in self.files if isinstance(f, AudioFile)]
-            if audio_files:
-                self.duration = audio_files[0].duration
             assert (
                 self.kind == content_kinds.AUDIO
             ), "Assumption Failed: Node should be audio"

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -161,9 +161,6 @@ VERSION_CHECK_URL = "{domain}/api/internal/check_version"
 # URL for getting file diff
 FILE_DIFF_URL = "{domain}/api/internal/file_diff"
 
-# URL for uploading files to server
-FILE_UPLOAD_URL = "{domain}/api/internal/file_upload"
-
 # URL for getting an upload URL from the server
 GET_UPLOAD_URL = "{domain}/api/file/upload_url"
 
@@ -400,14 +397,6 @@ def file_diff_url():
     Returns: string url to file_diff endpoint
     """
     return FILE_DIFF_URL.format(domain=DOMAIN)
-
-
-def file_upload_url():
-    """file_upload_url: returns url to upload files
-    Args: None
-    Returns: string url to file_upload endpoint
-    """
-    return FILE_UPLOAD_URL.format(domain=DOMAIN)
 
 
 def get_upload_url():

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -129,6 +129,7 @@ class ChannelManager:
                 "name": file_data.original_filename or file_data.get_filename(),
                 "file_format": file_data.extension,
                 "preset": file_data.get_preset(),
+                "duration": file_data.duration,
             }
             url_response = config.SESSION.post(config.get_upload_url(), data=data)
             if url_response.status_code == 200:
@@ -235,12 +236,7 @@ class ChannelManager:
                 # Attempt to upload file
                 try:
                     assert f.filename, "File failed to download (cannot be uploaded)"
-                    with open(config.get_storage_path(f.filename), "rb") as file_obj:
-                        response = config.SESSION.post(
-                            config.file_upload_url(), files={"file": file_obj}
-                        )
-                        response.raise_for_status()
-                        self.uploaded_files.append(f.filename)
+                    self.do_file_upload(f)
                 except AssertionError as ae:
                     config.LOGGER.warning(ae)
             # Attempt to create node


### PR DESCRIPTION
* Consolidates file duration onto the file object
* Removes inference of ContentNode level duration and defers that to Studio
* Renames content node duration to suggested_duration to match Studio
* Removes outdated upload code

Fixes #378