### PR TITLE
Add support for not processing files that already exist on remote

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -1283,8 +1283,6 @@ class RemoteFile(File):
     def validate(self):
         if not self._validated:
             file_url = config.get_storage_url(self.filename)
-            if config.DOMAIN == config.DEFAULT_DOMAIN:
-                file_url.replace("api.", "")
             response = config.DOWNLOAD_SESSION.head(file_url)
             try:
                 response.raise_for_status()

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -641,7 +641,10 @@ class AudioFile(DownloadFile):
 
     def process_file(self):
         self.filename = super(AudioFile, self).process_file()
-        self.duration = extract_duration_of_media(self.path)
+        if self.filename and config.get_storage_path(self.filename):
+            self.duration = extract_duration_of_media(
+                self.path, extract_path_ext(self.filename)
+            )
         return self.filename
 
 
@@ -772,7 +775,8 @@ class VideoFile(DownloadFile):
             if self.filename:
                 if config.get_storage_path(self.filename):
                     self.duration = extract_duration_of_media(
-                        config.get_storage_path(self.filename)
+                        config.get_storage_path(self.filename),
+                        extract_path_ext(self.filename),
                     )
         except (
             BrokenPipeError,
@@ -829,9 +833,10 @@ class WebVideoFile(File):
             if self.filename and config.COMPRESS:
                 self.filename = compress_video_file(self.filename, {})
                 config.LOGGER.info("\t--- Compressed {}".format(self.filename))
-            if config.get_storage_path(self.filename):
+            if self.filename and config.get_storage_path(self.filename):
                 self.duration = extract_duration_of_media(
-                    config.get_storage_path(self.filename)
+                    config.get_storage_path(self.filename),
+                    extract_path_ext(self.filename),
                 )
 
         except youtube_dl.utils.DownloadError as err:

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -878,7 +878,13 @@ class VideoNode(ContentNode):
         Args: None
         Returns: boolean indicating if video is valid
         """
-        from .files import VideoFile, WebVideoFile, SubtitleFile, YouTubeSubtitleFile
+        from .files import (
+            RemoteFile,
+            VideoFile,
+            WebVideoFile,
+            SubtitleFile,
+            YouTubeSubtitleFile,
+        )
 
         try:
             assert (
@@ -887,15 +893,18 @@ class VideoNode(ContentNode):
             assert (
                 self.questions == []
             ), "Assumption Failed: Video should not have questions"
-            assert (
-                len(self.files) > 0
-            ), "Assumption Failed: Video must have at least one video file"
 
             # Check if there are any .mp4 files if there are video files (other video types don't have paths)
             assert any(
                 f
                 for f in self.files
-                if isinstance(f, VideoFile) or isinstance(f, WebVideoFile)
+                if isinstance(f, VideoFile)
+                or isinstance(f, WebVideoFile)
+                or (
+                    isinstance(f, RemoteFile)
+                    and f.preset
+                    in (format_presets.VIDEO_HIGH_RES, format_presets.VIDEO_LOW_RES)
+                )
             ), "Assumption Failed: Video node should have at least one video file"
 
             # Ensure that there is only one subtitle file per language code
@@ -926,9 +935,7 @@ class VideoNode(ContentNode):
 
         except AssertionError as ae:
             raise InvalidNodeException(
-                "Invalid node ({}): {} - {}".format(
-                    ae.args[0], self.title, self.__dict__
-                )
+                "Invalid node {} - {}: {}".format(self.title, self.__dict__, ae)
             )
 
 
@@ -960,7 +967,7 @@ class AudioNode(ContentNode):
         Args: None
         Returns: boolean indicating if audio is valid
         """
-        from .files import AudioFile
+        from .files import AudioFile, RemoteFile
 
         try:
             assert (
@@ -973,7 +980,10 @@ class AudioNode(ContentNode):
                 len(self.files) > 0
             ), "Assumption Failed: Audio should have at least one file"
             assert [
-                f for f in self.files if isinstance(f, AudioFile)
+                f
+                for f in self.files
+                if isinstance(f, AudioFile)
+                or (isinstance(f, RemoteFile) and f.preset == format_presets.AUDIO)
             ], "Assumption Failed: Audio should have at least one audio file"
             return super(AudioNode, self).validate()
         except AssertionError as ae:
@@ -1012,7 +1022,7 @@ class DocumentNode(ContentNode):
         Args: None
         Returns: boolean indicating if document is valid
         """
-        from .files import DocumentFile, EPubFile
+        from .files import DocumentFile, EPubFile, RemoteFile
 
         try:
             assert (
@@ -1027,7 +1037,12 @@ class DocumentNode(ContentNode):
             assert [
                 f
                 for f in self.files
-                if isinstance(f, DocumentFile) or isinstance(f, EPubFile)
+                if isinstance(f, DocumentFile)
+                or isinstance(f, EPubFile)
+                or (
+                    isinstance(f, RemoteFile)
+                    and f.preset in (format_presets.DOCUMENT, format_presets.EPUB)
+                )
             ], "Assumption Failed: Document should have at least one document file"
             return super(DocumentNode, self).validate()
         except AssertionError as ae:
@@ -1107,7 +1122,7 @@ class HTML5AppNode(ContentNode):
         Args: None
         Returns: boolean indicating if HTML5 app is valid
         """
-        from .files import HTMLZipFile
+        from .files import HTMLZipFile, RemoteFile
 
         try:
             assert (
@@ -1117,7 +1132,10 @@ class HTML5AppNode(ContentNode):
                 self.questions == []
             ), "Assumption Failed: HTML should not have questions"
             assert [
-                f for f in self.files if isinstance(f, HTMLZipFile)
+                f
+                for f in self.files
+                if isinstance(f, HTMLZipFile)
+                or (isinstance(f, RemoteFile) and f.preset == format_presets.HTML5_ZIP)
             ], "Assumption Failed: HTML should have at least one html file"
             return super(HTML5AppNode, self).validate()
         except AssertionError as ae:
@@ -1155,7 +1173,7 @@ class H5PAppNode(ContentNode):
         Args: None
         Returns: boolean indicating if H5P app is valid
         """
-        from .files import H5PFile
+        from .files import H5PFile, RemoteFile
 
         try:
             assert (
@@ -1165,7 +1183,10 @@ class H5PAppNode(ContentNode):
                 self.questions == []
             ), "Assumption Failed: HTML should not have questions"
             assert [
-                f for f in self.files if isinstance(f, H5PFile)
+                f
+                for f in self.files
+                if isinstance(f, H5PFile)
+                or (isinstance(f, RemoteFile) and f.preset == format_presets.H5P_ZIP)
             ], "Assumption Failed: H5PAppNode should have at least one h5p file"
             return super(H5PAppNode, self).validate()
         except AssertionError as ae:

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -147,6 +147,11 @@ if DOMAIN.endswith("/"):
     DOMAIN = DOMAIN.rstrip("/")
 FILE_STORE_LOCATION = hashlib.md5(DOMAIN.encode("utf-8")).hexdigest()
 
+try:
+    TASK_THREADS = int(os.environ.get("TASK_THREADS"))
+except (ValueError, TypeError):
+    TASK_THREADS = 5
+
 CURRENT_CWD = os.getcwd()
 
 # Allow users to choose which phantomjs they use

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -417,9 +417,14 @@ def get_storage_url(filename):
     Args: filename (str): Name of file
     Returns: string URL for file
     """
-    return FILE_STORAGE_URL.format(
+    file_url = FILE_STORAGE_URL.format(
         domain=DOMAIN, f=filename[0], s=filename[1], filename=filename
     )
+    if DOMAIN == DEFAULT_DOMAIN:
+        # If we are targeting the default domain, don't make content storage requests
+        # to api.studio because it will skip cloudflare.
+        file_url.replace("api.", "")
+    return file_url
 
 
 def create_channel_url():

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -121,6 +121,8 @@ class ChannelManager:
         return file_diff_result
 
     def do_file_upload(self, f):
+        if f.skip_upload:
+            return
         with open(config.get_storage_path(f), "rb") as file_obj:
             file_data = self.file_map[f]
             data = {

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -149,11 +149,11 @@ class ChannelManager:
 
         return file_diff_result
 
-    def do_file_upload(self, f):
-        if f.skip_upload:
+    def do_file_upload(self, filename):
+        file_data = self.file_map[filename]
+        if file_data.skip_upload:
             return
-        with open(config.get_storage_path(f), "rb") as file_obj:
-            file_data = self.file_map[f]
+        with open(config.get_storage_path(filename), "rb") as file_obj:
             data = {
                 "size": file_data.size,
                 "checksum": file_data.checksum,
@@ -169,7 +169,9 @@ class ChannelManager:
                 content_type = response_data["mimetype"]
                 might_skip = response_data["might_skip"]
                 if might_skip:
-                    head_response = config.SESSION.head(config.get_storage_url(f))
+                    head_response = config.SESSION.head(
+                        config.get_storage_url(filename)
+                    )
                     if head_response.status_code == 200:
                         return
                 b64checksum = (

--- a/ricecooker/utils/jsontrees.py
+++ b/ricecooker/utils/jsontrees.py
@@ -37,6 +37,7 @@ HTML5_FILE = file_types.HTML5
 THUMBNAIL_FILE = file_types.THUMBNAIL
 SUBTITLES_FILE = file_types.SUBTITLES
 SLIDESHOW_IMAGE_FILE = file_types.SLIDESHOW_IMAGE
+REMOTE_FILE = "remote_file"
 
 
 INPUT_QUESTION = exercises.INPUT_QUESTION
@@ -262,6 +263,7 @@ def add_files(node, file_list):  # noqa: C901
         THUMBNAIL_FILE,
         SUBTITLES_FILE,
         SLIDESHOW_IMAGE_FILE,
+        REMOTE_FILE,
     ]
 
     for f in file_list:
@@ -360,6 +362,18 @@ def add_files(node, file_list):  # noqa: C901
                     language=f.get("language", None),
                     caption=f.get("caption", ""),
                     descriptive_text=f.get("descriptive_text", ""),
+                )
+            )
+
+        elif file_type == REMOTE_FILE:
+            node.add_file(
+                files.RemoteFile(
+                    f["checksum"],
+                    f["ext"],
+                    preset,
+                    is_primary=f.get("is_primary", False),
+                    language=f.get("language"),
+                    source_url=f.get("source_url"),
                 )
             )
 

--- a/ricecooker/utils/videos.py
+++ b/ricecooker/utils/videos.py
@@ -179,6 +179,35 @@ def compress_video(source_file_path, target_file, overwrite=False, **kwargs):
         "-strict",
         "-2",
         "-stats",
+        "-movflags",
+        "faststart",
+        target_file,
+    ]
+    try:
+        subprocess.check_output(command, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        raise VideoCompressionError("{}: {}".format(e, e.output))
+
+
+def web_faststart_video(source_file_path, target_file, overwrite=False):
+    """
+    Add faststart flag to an mp4 file
+    """
+    # run command
+    command = [
+        "ffmpeg",
+        "-y" if overwrite else "-n",
+        "-i",
+        source_file_path,
+        "-c",
+        "copy",
+        "-v",
+        "error",
+        "-strict",
+        "-2",
+        "-stats",
+        "-movflags",
+        "faststart",
         target_file,
     ]
     try:

--- a/ricecooker/utils/videos.py
+++ b/ricecooker/utils/videos.py
@@ -99,7 +99,41 @@ def extract_thumbnail_from_video(fpath_in, fpath_out, overwrite=False):
         raise ThumbnailGenerationError("{}: {}".format(e, e.output))
 
 
-def extract_duration_of_media(fpath_in):
+def _get_stream_duration(fpath_in, extension):
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            "pipe:",
+            "-f",
+            "null",
+            str(fpath_in),
+        ],
+        stderr=subprocess.PIPE,
+    )
+    second_last_line = result.stderr.decode("utf-8").strip().splitlines()[-2]
+    time_code = second_last_line.split(" time=")[1].split(" ")[0]
+    hours, minutes, seconds = time_code.split(":")
+    try:
+        hours = int(hours)
+    except ValueError:
+        hours = 0
+    try:
+        minutes = int(minutes)
+    except ValueError:
+        minutes = 0
+    try:
+        seconds = int(float(seconds))
+    except ValueError:
+        seconds = 0
+    return (hours * 60 + minutes) * 60 + seconds
+
+
+def extract_duration_of_media(fpath_in, extension):
+    """
+    For more details on these commands, refer to the ffmpeg Wiki:
+    https://trac.ffmpeg.org/wiki/FFprobeTips#Formatcontainerduration
+    """
     try:
         if os.path.exists(fpath_in):
             result = subprocess.check_output(
@@ -113,10 +147,18 @@ def extract_duration_of_media(fpath_in):
                     "default=noprint_wrappers=1:nokey=1",
                     "-loglevel",
                     "panic",
+                    "-f",
+                    extension,
                     str(fpath_in),
-                ]
+                ],
             )
-            return result.decode("utf-8")
+            result = result.decode("utf-8").strip()
+            try:
+                return int(float(result))
+            except ValueError:
+                # This can happen if ffprobe returns N/A for the duration
+                # So instead we try to stream the entire file to get the value
+                return _get_stream_duration(fpath_in, extension)
     except Exception as ex:
         LOGGER.warning(ex)
         raise ex


### PR DESCRIPTION
* Adds support for files that already exist on remote
* Threads validation, processing, and uploading to decrease processing time for ricecooker runs
* Always check/fetch content files on upstream from cloud flared domain, rather than api.
* Adds support for moving the faststart flag to the beginning of a file
* Improve logging for file upload failures
* Ensure file duration is properly coerced to an integer
* Give fallback for file duration extraction when the container cannot be used for file duration metadata