### PR TITLE
Fix upload check by doing replacement properly and using download session.

### DIFF
--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -409,7 +409,7 @@ def get_storage_url(filename):
     if DOMAIN == DEFAULT_DOMAIN:
         # If we are targeting the default domain, don't make content storage requests
         # to api.studio because it will skip cloudflare.
-        file_url.replace("api.", "")
+        file_url = file_url.replace("api.", "")
     return file_url
 
 

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -124,7 +124,7 @@ class ChannelManager:
             config.LOGGER.info("   All files were successfully downloaded")
 
     def check_file_exists(self, filename):
-        head_response = config.SESSION.head(config.get_storage_url(filename))
+        head_response = config.DOWNLOAD_SESSION.head(config.get_storage_url(filename))
         return head_response.status_code == 200
 
     def get_file_diff(self, files_to_diff):


### PR DESCRIPTION
The upload check was returning a 401 instead of a 200, because of issues using the regular SESSION.

Instead this uses the DOWNLOAD_SESSION which is not authenticated, and ensures that we do checks against base studio, to make sure we leverage cloudflare, and don't hit Google Cloud Storage.