### PR TITLE
Default values for some metadata on ContentNode set to list()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-all: clean-test ## run tests on every Python version with tox
 	tox
 
 integration-test:
-	python tests/test_chef_integration.py
+	CONTENTWORKSHOP_URL=https://hotfixes.studio.learningequality.org python tests/test_chef_integration.py
 
 coverage: ## check code coverage quickly with the default Python
 	pip install coverage pytest

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ test: clean-test ## run tests quickly with the default Python
 test-all: clean-test ## run tests on every Python version with tox
 	tox
 
+integration-test:
+	python tests/test_chef_integration.py
+
 coverage: ## check code coverage quickly with the default Python
 	pip install coverage pytest
 	coverage run --source ricecooker -m pytest

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,12 @@ test-all: clean-test ## run tests on every Python version with tox
 	tox
 
 integration-test:
+	echo "Testing against hotfixes"
 	CONTENTWORKSHOP_URL=https://hotfixes.studio.learningequality.org python tests/test_chef_integration.py
+	echo "Testing against unstable"
+	CONTENTWORKSHOP_URL=https://unstable.studio.learningequality.org python tests/test_chef_integration.py
+	echo "Testing against production"
+	CONTENTWORKSHOP_URL=https://studio.learningequality.org python tests/test_chef_integration.py
 
 coverage: ## check code coverage quickly with the default Python
 	pip install coverage pytest

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -463,6 +463,12 @@ class TreeNode(Node):
         provider="",
         tags=None,
         domain_ns=None,
+        grade_levels=None,
+        resource_types=None,
+        learning_activities=None,
+        accessibility_labels=None,
+        categories=None,
+        learner_needs=None,
         **kwargs
     ):
         # Map parameters to model variables
@@ -477,6 +483,13 @@ class TreeNode(Node):
         self.questions = (
             self.questions if hasattr(self, "questions") else []
         )  # Needed for to_dict method
+
+        self.grade_levels = grade_levels or []
+        self.resource_types = resource_types or []
+        self.learning_activities = learning_activities or []
+        self.accessibility_labels = accessibility_labels or []
+        self.categories = categories or []
+        self.learner_needs = learner_needs or []
 
         super(TreeNode, self).__init__(title, **kwargs)
 
@@ -569,12 +582,12 @@ class TreeNode(Node):
             "copyright_holder": "",
             "questions": [],
             "extra_fields": json.dumps(self.extra_fields),
-            "grade_levels": None,
-            "resource_types": None,
-            "learning_activities": None,
-            "accessibility_categories": None,
-            "subjects": None,
-            "needs": None,
+            "grade_levels": self.grade_levels,
+            "resource_types": self.resource_types,
+            "learning_activities": self.learning_activities,
+            "accessibility_labels": self.accessibility_labels,
+            "categories": self.categories,
+            "learner_needs": self.learner_needs,
         }
 
     def validate(self):
@@ -677,21 +690,15 @@ class ContentNode(TreeNode):
         role=roles.LEARNER,
         license_description=None,
         copyright_holder=None,
-        grade_levels=[],
-        resource_types=[],
-        learning_activities=[],
-        accessibility_labels=[],
-        categories=[],
-        learner_needs=[],
+        grade_levels=None,
+        resource_types=None,
+        learning_activities=None,
+        accessibility_labels=None,
+        categories=None,
+        learner_needs=None,
         **kwargs
     ):
         self.role = role
-        self.grade_levels = grade_levels
-        self.resource_types = resource_types
-        self.learning_activities = learning_activities
-        self.accessibility_labels = accessibility_labels
-        self.categories = categories
-        self.learner_needs = learner_needs
 
         self.set_license(
             license, copyright_holder=copyright_holder, description=license_description
@@ -823,12 +830,6 @@ class ContentNode(TreeNode):
             "extra_fields": json.dumps(self.extra_fields),
             "role": self.role,
             "suggested_duration": self.suggested_duration,
-            "grade_levels": self.grade_levels,
-            "resource_types": self.resource_types,
-            "learning_activities": self.learning_activities,
-            "accessibility_labels": self.accessibility_labels,
-            "categories": self.categories,
-            "learner_needs": self.learner_needs,
         }
 
 

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -830,6 +830,12 @@ class ContentNode(TreeNode):
             "extra_fields": json.dumps(self.extra_fields),
             "role": self.role,
             "suggested_duration": self.suggested_duration,
+            "grade_levels": self.grade_levels,
+            "resource_types": self.resource_types,
+            "learning_activities": self.learning_activities,
+            "accessibility_labels": self.accessibility_labels,
+            "categories": self.categories,
+            "learner_needs": self.learner_needs,
         }
 
 

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -677,12 +677,12 @@ class ContentNode(TreeNode):
         role=roles.LEARNER,
         license_description=None,
         copyright_holder=None,
-        grade_levels=None,
-        resource_types=None,
-        learning_activities=None,
-        accessibility_labels=None,
-        categories=None,
-        learner_needs=None,
+        grade_levels=[],
+        resource_types=[],
+        learning_activities=[],
+        accessibility_labels=[],
+        categories=[],
+        learner_needs=[],
         **kwargs
     ):
         self.role = role
@@ -826,9 +826,9 @@ class ContentNode(TreeNode):
             "grade_levels": self.grade_levels,
             "resource_types": self.resource_types,
             "learning_activities": self.learning_activities,
-            "accessibility_categories": self.accessibility_labels,
-            "subjects": self.categories,
-            "needs": self.learner_needs,
+            "accessibility_labels": self.accessibility_labels,
+            "categories": self.categories,
+            "learner_needs": self.learner_needs,
         }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,12 @@ def base_data(channel_domain_namespace, title):
         "license_description": None,
         "aggregator": "",  # New in ricecooker 0.6.20
         "provider": "",  # New in ricecooker 0.6.20
+        "grade_levels": [],
+        "resource_types": [],
+        "learning_activities": [],
+        "accessibility_labels": [],
+        "categories": [],
+        "learner_needs": [],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,6 +259,12 @@ def contentnode_base_data(base_data):
             "copyright_holder": "Copyright Holder",
             "license_description": None,
             "role": roles.LEARNER,
+            "grade_levels": [],
+            "resource_types": [],
+            "learning_activities": [],
+            "accessibility_labels": [],
+            "categories": [],
+            "learner_needs": [],
         }
     )
     return data

--- a/tests/test_chef_integration.py
+++ b/tests/test_chef_integration.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+import random
+import string
+
 from le_utils.constants import licenses
 
 from ricecooker.chefs import SushiChef
@@ -21,9 +24,22 @@ class TestChef(SushiChef):
     Copied from examples/tutorial/sushichef.py
     """
 
+    # Be sure we don't conflict with a channel someone else pushed before us when running this test
+    # as the channel source domain and ID determine which Channel is updated on Studio and since
+    # you'll run this with your own API key we can use this random (enough) string generator (thanks SO)
+    # to append a random set of characters to the two values.
+    def randomstring():
+        return "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(8)
+        )
+
     channel_info = {
-        "CHANNEL_SOURCE_DOMAIN": "Testing",  # who is providing the content (e.g. learningequality.org)
-        "CHANNEL_SOURCE_ID": "Test-ID",  # channel's unique id
+        "CHANNEL_SOURCE_DOMAIN": "RicecookerIntegrationTest.{}".format(
+            randomstring()
+        ),  # who is providing the content (e.g. learningequality.org)
+        "CHANNEL_SOURCE_ID": "RicecookerTests.{}".format(
+            randomstring()
+        ),  # channel's unique id
         "CHANNEL_TITLE": "Ricecooker Testing!",
         "CHANNEL_LANGUAGE": "en",
     }

--- a/tests/test_chef_integration.py
+++ b/tests/test_chef_integration.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+from le_utils.constants import licenses
+
+from ricecooker.chefs import SushiChef
+from ricecooker.classes.files import AudioFile
+from ricecooker.classes.files import DocumentFile
+from ricecooker.classes.files import VideoFile
+from ricecooker.classes.licenses import get_license
+from ricecooker.classes.nodes import AudioNode
+from ricecooker.classes.nodes import DocumentNode
+from ricecooker.classes.nodes import TopicNode
+from ricecooker.classes.nodes import VideoNode
+
+
+class TestChef(SushiChef):
+    """
+    Used as an integration test by actually using Ricecooker to chef local test content into Studio.
+
+    For anything you need to test, add it to the channel created in the `construct_channel`.
+
+    Copied from examples/tutorial/sushichef.py
+    """
+
+    channel_info = {
+        "CHANNEL_SOURCE_DOMAIN": "Testing",  # who is providing the content (e.g. learningequality.org)
+        "CHANNEL_SOURCE_ID": "Test-ID",  # channel's unique id
+        "CHANNEL_TITLE": "Ricecooker Testing!",
+        "CHANNEL_LANGUAGE": "en",
+    }
+
+    # CONSTRUCT CHANNEL
+    def construct_channel(self, *args, **kwargs):
+        """
+        This method is reponsible for creating a `ChannelNode` object and
+        populating it with `TopicNode` and `ContentNode` children.
+        """
+        # Create channel
+        ########################################################################
+        channel = self.get_channel(*args, **kwargs)  # uses self.channel_info
+
+        # Create topics to add to your channel
+        ########################################################################
+        # Here we are creating a topic named 'Example Topic'
+        exampletopic = TopicNode(source_id="topic-1", title="Example Topic")
+
+        # Now we are adding 'Example Topic' to our channel
+        channel.add_child(exampletopic)
+
+        # You can also add subtopics to topics
+        # Here we are creating a subtopic named 'Example Subtopic'
+        examplesubtopic = TopicNode(source_id="topic-1a", title="Example Subtopic")
+
+        # Now we are adding 'Example Subtopic' to our 'Example Topic'
+        exampletopic.add_child(examplesubtopic)
+
+        # Content
+        # You can add documents (pdfs and ePubs), videos, audios, and other content
+        # let's create a document file called 'Example PDF'
+        document_file = DocumentFile(path="http://www.pdf995.com/samples/pdf.pdf")
+        examplepdf = DocumentNode(
+            title="Example PDF",
+            source_id="example-pdf",
+            files=[document_file],
+            license=get_license(licenses.PUBLIC_DOMAIN),
+        )
+
+        # We are also going to add a video file called 'Example Video'
+        video_file = VideoFile(
+            path="https://ia600209.us.archive.org/27/items/RiceChef/Rice Chef.mp4"
+        )
+        fancy_license = get_license(
+            licenses.SPECIAL_PERMISSIONS,
+            description="Special license for ricecooker fans only.",
+            copyright_holder="The chef video makers",
+        )
+        examplevideo = VideoNode(
+            title="Example Video",
+            source_id="example-video",
+            files=[video_file],
+            license=fancy_license,
+        )
+
+        # Finally, we are creating an audio file called 'Example Audio'
+        audio_file = AudioFile(
+            path="https://ia802508.us.archive.org/5/items/testmp3testfile/mpthreetest.mp3"
+        )
+        exampleaudio = AudioNode(
+            title="Example Audio",
+            source_id="example-audio",
+            files=[audio_file],
+            license=get_license(licenses.PUBLIC_DOMAIN),
+        )
+
+        # Now that we have our files, let's add them to our channel
+        channel.add_child(examplepdf)  # Adding 'Example PDF' to your channel
+        exampletopic.add_child(
+            examplevideo
+        )  # Adding 'Example Video' to 'Example Topic'
+        examplesubtopic.add_child(
+            exampleaudio
+        )  # Adding 'Example Audio' to 'Example Subtopic'
+
+        # the `construct_channel` method returns a ChannelNode that will be
+        # processed by the ricecooker framework
+        return channel
+
+
+if __name__ == "__main__":
+    """
+    This code will run when the sushi chef is called from the command line.
+    """
+    chef = TestChef()
+    print(
+        "Note that you will need your Studio API key for this. It will upload to your account."
+    )
+    chef.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -145,10 +145,26 @@ def test_video_to_dict(video, video_data):
     video_dict.pop("files")
     expected_files = video_data.pop("files")
     video_data["extra_fields"] = json.dumps(video_data["extra_fields"])
+
     assert video.files == expected_files, "Video files do not match"
+
     for key, _ in video_data.items():
         assert key in video_dict, "Key {} is not found in to_dict method".format(key)
+
+    list_type_keys = [
+        "grade_levels",
+        "learner_needs",
+        "accessibility_labels",
+        "categories",
+        "learning_activities",
+        "resource_types",
+    ]
     for key, value in video_dict.items():
+        if key in list_type_keys:
+            assert isinstance(value, list), "{} should be a list, but it's {}".format(
+                key, value
+            )
+
         assert value == video_data.get(key), "Mismatched {}: {} != {}".format(
             key, value, video_data[key]
         )


### PR DESCRIPTION
Fixes #385 

@AllanOXDi and I worked through this together.

We updated the default values for the metadata values in ContentNode to an empty list rather than None. This should resolve the reported issue.

To test this, we enumerated the keys that must default to a list and ensure a default ContentNode descendant is initialized with an empty list. This test logic is only added to the test function that tests Video content -- as all content types descend from ContentNode, this test should be sufficient coverage without duplicating the code across each of the functions.

The existing tests failed because of the improperly matched labels -- we changed the names in `nodes.py`. The tests check that a defined fixture is correct against a created instance -- so please double check this for us in case we misunderstood as the change may have needed to occur at the `conftest.py` definition of the fixtures.