### PR TITLE
Add StudioContentNode class to allow scripted curation of existing content from Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ video_cache_py3.sqlite
 .vim/
 
 cache.sqlite
+
+chefdata/

--- a/examples/remotecontent/sushichef.py
+++ b/examples/remotecontent/sushichef.py
@@ -15,6 +15,7 @@ curates content from another channel already on Studio into a new channel.
 
 SOURCE_DOMAIN = "testdomain.org"  ## change me!
 
+# global dict to retain state between the two chef runs
 original_channel_data = {
     "channel_id": None,
     "doc_node_id": None,

--- a/examples/remotecontent/sushichef.py
+++ b/examples/remotecontent/sushichef.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+from ricecooker.chefs import SushiChef
+from ricecooker.classes.files import AudioFile
+from ricecooker.classes.files import DocumentFile
+from ricecooker.classes.licenses import get_license
+from ricecooker.classes.nodes import AudioNode
+from ricecooker.classes.nodes import DocumentNode
+from ricecooker.classes.nodes import RemoteContentNode
+from ricecooker.classes.nodes import TopicNode
+
+"""
+This example shows how to use the RemoteContentNode to create a channel that
+curates content from another channel already on Studio into a new channel.
+"""
+
+SOURCE_DOMAIN = "testdomain.org"  ## change me!
+
+original_channel_data = {
+    "channel_id": None,
+    "doc_node_id": None,
+    "audio_node_id": None,
+}
+
+
+class OriginalChannelChef(SushiChef):
+    channel_info = {
+        "CHANNEL_TITLE": "Original channel",
+        "CHANNEL_SOURCE_DOMAIN": SOURCE_DOMAIN,
+        "CHANNEL_SOURCE_ID": "originalchannel",
+        "CHANNEL_LANGUAGE": "en",
+    }
+
+    def construct_channel(self, **kwargs):
+        channel = self.get_channel(**kwargs)
+
+        document_node = DocumentNode(
+            title="Growing potatoes",
+            description="An article about growing potatoes on your rooftop.",
+            source_id="pubs/mafri-potatoe",
+            license=get_license("CC BY", copyright_holder="University of Alberta"),
+            files=[
+                DocumentFile(
+                    path="https://www.gov.mb.ca/inr/pdf/pubs/mafri-potatoe.pdf",
+                    language="en",
+                )
+            ],
+        )
+        channel.add_child(document_node)
+
+        audio_node = AudioNode(
+            source_id="also-sprach",
+            title="Also Sprach Zarathustra",
+            author="Kevin MacLeod / Richard Strauss",
+            description="Also Sprach Zarathustra, Op. 30, is a tone poem by Richard Strauss, composed in 1896.",
+            license=get_license("CC BY", copyright_holder="Kevin MacLeod"),
+            files=[
+                AudioFile(
+                    "https://ia600702.us.archive.org/33/items/Classical_Sampler-9615/Kevin_MacLeod_-_Also_Sprach_Zarathustra.mp3"
+                )
+            ],
+        )
+        channel.add_child(audio_node)
+
+        return channel
+
+
+class CuratedChannelChef(SushiChef):
+    channel_info = {
+        "CHANNEL_TITLE": "Curated channel",
+        "CHANNEL_SOURCE_DOMAIN": SOURCE_DOMAIN,
+        "CHANNEL_SOURCE_ID": "curatedchannel",
+        "CHANNEL_LANGUAGE": "en",
+    }
+
+    def construct_channel(self, **kwargs):
+        channel = self.get_channel(**kwargs)
+
+        document_topic = TopicNode(
+            title="Documents",
+            source_id="documents",
+        )
+        channel.add_child(document_topic)
+        remote_document = RemoteContentNode(
+            title="Glorious new title for the potato doc",
+            source_channel_id=original_channel_data["channel_id"],
+            source_node_id=original_channel_data["doc_node_id"],
+        )
+        document_topic.add_child(remote_document)
+
+        audio_topic = TopicNode(
+            title="Audio",
+            source_id="audio",
+        )
+        channel.add_child(audio_topic)
+        remote_audio = RemoteContentNode(
+            source_channel_id=original_channel_data["channel_id"],
+            source_node_id=original_channel_data["audio_node_id"],
+        )
+        audio_topic.add_child(remote_audio)
+
+        return channel
+
+
+if __name__ == "__main__":
+    """
+    Run this script on the command line using:
+        python sushichef.py --token=YOURTOKENHERE9139139f3a23232
+    """
+    original_chef = OriginalChannelChef()
+    original_chef.main()
+    original_channel = original_chef.construct_channel()
+
+    original_channel_data["channel_id"] = original_channel.get_node_id().hex
+    original_channel_data["doc_node_id"] = (
+        original_channel.children[0].get_node_id().hex
+    )
+    original_channel_data["audio_node_id"] = (
+        original_channel.children[1].get_node_id().hex
+    )
+
+    input(
+        "Please visit the URL above and deploy the channel, and wait for it to finish. Then press enter to continue..."
+    )
+
+    curated_chef = CuratedChannelChef()
+    curated_chef.main()

--- a/examples/studiocontent/sushichef.py
+++ b/examples/studiocontent/sushichef.py
@@ -5,11 +5,11 @@ from ricecooker.classes.files import DocumentFile
 from ricecooker.classes.licenses import get_license
 from ricecooker.classes.nodes import AudioNode
 from ricecooker.classes.nodes import DocumentNode
-from ricecooker.classes.nodes import RemoteContentNode
+from ricecooker.classes.nodes import StudioContentNode
 from ricecooker.classes.nodes import TopicNode
 
 """
-This example shows how to use the RemoteContentNode to create a channel that
+This example shows how to use the StudioContentNode to create a channel that
 curates content from another channel already on Studio into a new channel.
 """
 
@@ -81,7 +81,7 @@ class CuratedChannelChef(SushiChef):
             source_id="documents",
         )
         channel.add_child(document_topic)
-        remote_document = RemoteContentNode(
+        remote_document = StudioContentNode(
             title="Glorious new title for the potato doc",
             source_channel_id=original_channel_data["channel_id"],
             source_node_id=original_channel_data["doc_node_id"],
@@ -93,7 +93,7 @@ class CuratedChannelChef(SushiChef):
             source_id="audio",
         )
         channel.add_child(audio_topic)
-        remote_audio = RemoteContentNode(
+        remote_audio = StudioContentNode(
             source_channel_id=original_channel_data["channel_id"],
             source_node_id=original_channel_data["audio_node_id"],
         )

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -1391,9 +1391,9 @@ class TiledThumbnailFile(ThumbnailPresetMixin, File):
             return filename
 
 
-class RemoteFile(File):
+class StudioFile(File):
     """
-    Reuse a file that we already know to exist on the remote (normally Studio).
+    Reuse a file that we already know to exist on the remote (Studio).
     This allows for channels to be updated without having to redownload all files again.
     """
 
@@ -1404,7 +1404,7 @@ class RemoteFile(File):
         self.is_primary = is_primary
         kwargs["preset"] = preset
         self._validated = False
-        super(RemoteFile, self).__init__(**kwargs)
+        super(StudioFile, self).__init__(**kwargs)
 
     def validate(self):
         if not self._validated:
@@ -1422,3 +1422,7 @@ class RemoteFile(File):
 
     def __str__(self):
         return self.filename
+
+
+# add alias for back-compatibility
+RemoteFile = StudioFile

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -882,7 +882,7 @@ class VideoNode(ContentNode):
         Returns: boolean indicating if video is valid
         """
         from .files import (
-            RemoteFile,
+            StudioFile,
             VideoFile,
             WebVideoFile,
             SubtitleFile,
@@ -904,7 +904,7 @@ class VideoNode(ContentNode):
                 if isinstance(f, VideoFile)
                 or isinstance(f, WebVideoFile)
                 or (
-                    isinstance(f, RemoteFile)
+                    isinstance(f, StudioFile)
                     and f.preset
                     in (format_presets.VIDEO_HIGH_RES, format_presets.VIDEO_LOW_RES)
                 )
@@ -970,7 +970,7 @@ class AudioNode(ContentNode):
         Args: None
         Returns: boolean indicating if audio is valid
         """
-        from .files import AudioFile, RemoteFile
+        from .files import AudioFile, StudioFile
 
         try:
             assert (
@@ -986,7 +986,7 @@ class AudioNode(ContentNode):
                 f
                 for f in self.files
                 if isinstance(f, AudioFile)
-                or (isinstance(f, RemoteFile) and f.preset == format_presets.AUDIO)
+                or (isinstance(f, StudioFile) and f.preset == format_presets.AUDIO)
             ], "Assumption Failed: Audio should have at least one audio file"
             return super(AudioNode, self).validate()
         except AssertionError as ae:
@@ -1025,7 +1025,7 @@ class DocumentNode(ContentNode):
         Args: None
         Returns: boolean indicating if document is valid
         """
-        from .files import DocumentFile, EPubFile, RemoteFile
+        from .files import DocumentFile, EPubFile, StudioFile
 
         try:
             assert (
@@ -1043,7 +1043,7 @@ class DocumentNode(ContentNode):
                 if isinstance(f, DocumentFile)
                 or isinstance(f, EPubFile)
                 or (
-                    isinstance(f, RemoteFile)
+                    isinstance(f, StudioFile)
                     and f.preset in (format_presets.DOCUMENT, format_presets.EPUB)
                 )
             ], "Assumption Failed: Document should have at least one document file"
@@ -1125,7 +1125,7 @@ class HTML5AppNode(ContentNode):
         Args: None
         Returns: boolean indicating if HTML5 app is valid
         """
-        from .files import HTMLZipFile, RemoteFile
+        from .files import HTMLZipFile, StudioFile
 
         try:
             assert (
@@ -1138,7 +1138,7 @@ class HTML5AppNode(ContentNode):
                 f
                 for f in self.files
                 if isinstance(f, HTMLZipFile)
-                or (isinstance(f, RemoteFile) and f.preset == format_presets.HTML5_ZIP)
+                or (isinstance(f, StudioFile) and f.preset == format_presets.HTML5_ZIP)
             ], "Assumption Failed: HTML should have at least one html file"
             return super(HTML5AppNode, self).validate()
         except AssertionError as ae:
@@ -1176,7 +1176,7 @@ class H5PAppNode(ContentNode):
         Args: None
         Returns: boolean indicating if H5P app is valid
         """
-        from .files import H5PFile, RemoteFile
+        from .files import H5PFile, StudioFile
 
         try:
             assert (
@@ -1189,7 +1189,7 @@ class H5PAppNode(ContentNode):
                 f
                 for f in self.files
                 if isinstance(f, H5PFile)
-                or (isinstance(f, RemoteFile) and f.preset == format_presets.H5P_ZIP)
+                or (isinstance(f, StudioFile) and f.preset == format_presets.H5P_ZIP)
             ], "Assumption Failed: H5PAppNode should have at least one h5p file"
             return super(H5PAppNode, self).validate()
         except AssertionError as ae:
@@ -1561,7 +1561,7 @@ class PracticeQuizNode(ExerciseNode):
         super(PracticeQuizNode, self).__init__(*args, **kwargs)
 
 
-class RemoteContentNode(TreeNode):
+class StudioContentNode(TreeNode):
     """
     Node class for creating content nodes in the channel that are imported from
     existing nodes in another channel on Studio.
@@ -1607,7 +1607,7 @@ class RemoteContentNode(TreeNode):
         )
         self.overrides = kwargs.copy()
         overriden_title = kwargs.pop("title", "<title from remote>")
-        super(RemoteContentNode, self).__init__(
+        super(StudioContentNode, self).__init__(
             source_node_id or source_content_id, overriden_title, **kwargs
         )
 
@@ -1623,11 +1623,11 @@ class RemoteContentNode(TreeNode):
         for key in self.overrides:
             if key not in self.ALLOWED_OVERRIDES:
                 raise InvalidNodeException(
-                    "Invalid node: '{}' cannot be overriden on a RemoteContentNode.".format(
+                    "Invalid node: '{}' cannot be overriden on a StudioContentNode.".format(
                         key
                     )
                 )
-        super(RemoteContentNode, self).validate()
+        super(StudioContentNode, self).validate()
 
     def to_dict(self):
         data = {
@@ -1643,3 +1643,7 @@ class RemoteContentNode(TreeNode):
             del self.overrides["thumbnail"]
         data.update(self.overrides)
         return data
+
+
+# add alias for back-compatibility
+RemoteContentNode = StudioContentNode

--- a/ricecooker/utils/jsontrees.py
+++ b/ricecooker/utils/jsontrees.py
@@ -367,7 +367,7 @@ def add_files(node, file_list):  # noqa: C901
 
         elif file_type == REMOTE_FILE:
             node.add_file(
-                files.RemoteFile(
+                files.StudioFile(
                     f["checksum"],
                     f["ext"],
                     preset,

--- a/ricecooker/utils/utils.py
+++ b/ricecooker/utils/utils.py
@@ -1,4 +1,15 @@
 import os
+import re
+
+
+VALID_UUID_REGEX = re.compile("^([a-f0-9]{32})$")
+
+
+def is_valid_uuid_string(uuid_str):
+    """
+    Check if a string is a valid UUID.
+    """
+    return isinstance(uuid_str, str) and VALID_UUID_REGEX.match(uuid_str)
 
 
 def make_dir_if_needed(path):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "le-pycaption>=2.2.0a1",
         "EbookLib>=0.17.1",
         "filetype>=1.1.0",
+        "urllib3==1.26.15",
     ],
     python_requires=">=3.7, <3.11",
     license="MIT license",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "requests_file",
         "beautifulsoup4>=4.6.3,<4.9.0",  # pinned to match versions in le-pycaption
         "selenium==3.0.1",
-        "yt-dlp>=2023.3.4",
+        "yt-dlp==2023.7.6",
         "html5lib",
         "cachecontrol==0.12.11",
         "lockfile==0.12.2",  # This is needed, but not specified as a dependency by cachecontrol

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,7 +236,7 @@ def topic_data(base_data, channel_domain_namespace, channel_node_id):
     topic_data = copy.deepcopy(base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     topic_data.update(ids_dict)
-    topic_data.update({"kind": content_kinds.TOPIC})
+    topic_data.update({"kind": content_kinds.TOPIC, "role": roles.LEARNER})
     return topic_data
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -546,8 +546,8 @@ def test_convertible_substitles_from_pressurcooker(pressurcooker_test_files):
         assert os.path.exists(localpath), "Error mising local test file " + localpath
         subtitle_file = SubtitleFile(localpath, language=fixture["language"])
         filename = subtitle_file.process_file()
-        assert filename, "conferted filename must exit"
-        assert filename.endswith(".vtt"), "conferted filename must have .vtt extension"
+        assert filename, "converted filename must exist"
+        assert filename.endswith(".vtt"), "converted filename must have .vtt extension"
         storage_path = config.get_storage_path(filename)
         with open(storage_path, encoding="utf-8") as converted_vtt:
             filecontents = converted_vtt.read()
@@ -575,8 +575,8 @@ def test_convertible_substitles_ar_ttml(youtube_test_file):
     assert os.path.exists(local_path)
     subtitle_file = SubtitleFile(local_path, language="ar")
     filename = subtitle_file.process_file()
-    assert filename, "conferted filename must exit"
-    assert filename.endswith(".vtt"), "conferted filename must have .vtt extension"
+    assert filename, "converted filename must exist"
+    assert filename.endswith(".vtt"), "converted filename must have .vtt extension"
 
 
 def test_convertible_substitles_noext_subtitlesformat():
@@ -604,8 +604,8 @@ def test_convertible_substitles_noext_subtitlesformat():
         subtitlesformat="ttml",  # settting subtitlesformat becaue no ext
     )
     filename = subtitle_file.process_file()
-    assert filename, "conferted filename must exit"
-    assert filename.endswith(".vtt"), "conferted filename must have .vtt extension"
+    assert filename, "converted filename must exist"
+    assert filename.endswith(".vtt"), "converted filename must have .vtt extension"
 
 
 def test_convertible_substitles_weirdext_subtitlesformat():
@@ -623,8 +623,8 @@ def test_convertible_substitles_weirdext_subtitlesformat():
         subtitlesformat="srt",  # set subtitlesformat when can't inferr ext form url
     )
     filename = subtitle_file.process_file()
-    assert filename, "conferted filename must exit"
-    assert filename.endswith(".vtt"), "conferted filename must have .vtt extension"
+    assert filename, "converted filename must exist"
+    assert filename.endswith(".vtt"), "converted filename must have .vtt extension"
     storage_path = config.get_storage_path(filename)
     with open(storage_path, encoding="utf-8") as converted_vtt:
         filecontents = converted_vtt.read()


### PR DESCRIPTION
In order to support the ability to create a new channel that includes content nodes that already exist on Kolibri Studio, this PR introduces a new node class called `StudioContentNode`, which is provided with a reference to the IDs of content nodes that already exist on Studio, along with potential overrides of existing metadata such as the title, tags, or thumbnail. Studio then clones the existing node from its source channel and puts it into the appropriate spot in this newly cheffed channel.

This PR depends on changes @rtibbles shall shortly open a PR for on https://github.com/learningequality/studio.