### PR TITLE
Update the ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
 python:
-  version: 3
   install:
-    - requirements: docs/requirements.txt
-  system_packages: true
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

This aligns the ReadTheDocs configuration file with our other projects by
- adding build settings and sphinx config path
- removing deprecated `sytem_packages`

## Reviewer guidance

- Preview the configuration file
- Preview the ReadTheDocs build of Ricecooker dev docs TODO