### PR TITLE
Update ReadTheDocs builds configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,12 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
+  jobs:
+    pre_install:
+      - pip install -e .
 sphinx:
   configuration: docs/conf.py
 python:
   install:
     - requirements: docs/requirements.txt
-  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,12 @@
 version: 2
 formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
 python:
-  version: 3
   install:
     - requirements: docs/requirements.txt
   system_packages: true


### PR DESCRIPTION
## Summary
- Updates .readthedocs.yml to the latest supported format and to be consistent with other projects
- Removes deprecated 'system_packages'
  ![Screenshot from 2023-09-15 14-07-44](https://github.com/learningequality/ricecooker/assets/13509191/84e25605-666d-422c-88dc-9d8e77605747)
  - This also requires adding a job to install `ricecooker` package explicitly (it's used in the Sphinx conf for getting version) and using Python 3.10 for docs build as the package is not compatible with 3.11

## References

https://blog.readthedocs.com/migrate-configuration-v2/
https://blog.readthedocs.com/drop-support-system-packages/

## Reviewer guidance

- Preview the configuration file
- Preview the production docs build: https://ricecooker--450.org.readthedocs.build/en/450/
- Preview the local docs build