### PR TITLE
Use the right object to get the error information

### DIFF
--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -190,7 +190,7 @@ class ChannelManager:
             else:
                 raise RequestException(
                     "Error retrieving upload URL for file {}, response code: {} - {}".format(
-                        filename, url_response.status_code, response.text
+                        filename, url_response.status_code, url_response.text
                     )
                 )
 


### PR DESCRIPTION
In the current code, when a POST to https://api.studio.learningequality.org/api/file/upload_url does not return a 200 code, the exception is  using the wrong object to build the error message