### PR TITLE
Use blacklisted urls in the static assets

### DIFF
--- a/ricecooker/utils/downloader.py
+++ b/ricecooker/utils/downloader.py
@@ -488,6 +488,9 @@ def download_static_assets(  # noqa: C901
 
         return _CSS_URL_RE.sub(repl, content)
 
+    if link_policy is not None and "blacklist" in link_policy:
+        url_blacklist += link_policy["blacklist"]
+
     # Download all linked static assets.
     download_assets("img[src]", "src")  # Images
     download_srcset("img[srcset]", "srcset")  # Images


### PR DESCRIPTION
When using `get_page` method from the `ArchiveDownloader`, as explained at https://github.com/learningequality/ricecooker/blob/develop/docs/downloader.md , the `policy` allows a list of `blacklisted` urls can be added.

However these urls where not used when downloading static assets refered by the main html pages.

This PR adds the blacklisted  urls from the policy to the `url_blacklist` property used to block static assets downloads.