### PR TITLE
Add action to send Slack notification about comments on issues

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -1,0 +1,35 @@
+name: Send a slack notification when a contributor comments on issue
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  contributor_issue_comment:
+    name: Contributor issue comment
+
+    if: >-
+      ${{
+        !github.event.issue.pull_request &&
+        github.event.comment.author_association != 'MEMBER' &&
+        github.event.comment.author_association != 'OWNER'
+      }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Escape title double quotes
+        id: escape_title
+        run: |
+          title='${{ github.event.issue.title }}'
+          echo "ISSUE_TITLE=${title//\"/\\\"}" >> "$GITHUB_OUTPUT"
+
+      - name: Send message to Slack channel
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "*[Ricecooker] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
+            }


### PR DESCRIPTION
This is a copy of the same action we use in other repos