### PR TITLE
Set default learning_activity based on node kind in TreeNode

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -32,12 +32,12 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
         python-version: [3.8, 3.9, '3.10']
         include:
         - os: ubuntu-latest
           pippath: ~/.cache/pip
-        - os: macos-latest
+        - os: macos-13
           pippath: ~/Library/Caches/pip
         - os: windows-latest
           pippath: ~\AppData\Local\pip\Cache
@@ -55,13 +55,13 @@ jobs:
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
     - name: Cache Mac dependencies
       uses: actions/cache@v4
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-13'
       with:
         path: ~/Library/Caches/Homebrew
         key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Install Mac dependencies
       run: brew install ffmpeg poppler
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-13'
     - name: Windows dependencies cache
       id: windowscache
       if: matrix.os == 'windows-latest'

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -26,6 +26,16 @@ MASTERY_MODELS = [id for id, name in exercises.MASTERY_MODELS]
 ROLES = [id for id, name in roles.choices]
 
 
+# Used to map content kind to learning activity when a list of learning_activiies is not provided
+kind_activity_map = {
+    content_kinds.EXERCISE: learning_activities.PRACTICE,
+    content_kinds.VIDEO: learning_activities.WATCH,
+    content_kinds.AUDIO: learning_activities.LISTEN,
+    content_kinds.DOCUMENT: learning_activities.READ,
+    content_kinds.HTML5: learning_activities.EXPLORE,
+    content_kinds.H5P: learning_activities.EXPLORE,
+}
+
 class Node(object):
     """Node: model to represent all nodes in the tree"""
 
@@ -488,7 +498,13 @@ class TreeNode(Node):
 
         self.grade_levels = grade_levels or []
         self.resource_types = resource_types or []
-        self.learning_activities = learning_activities or []
+
+        # learning_activities can be set to a default based on the kind if not provided directly
+        if self.kind in kind_activity_map and not learning_activities:
+            self.learning_activities = [kind_activity_map[self.kind]]
+        else:
+            self.learning_activities = learning_activities
+
         self.accessibility_labels = accessibility_labels or []
         self.categories = categories or []
         self.learner_needs = learner_needs or []

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -36,6 +36,7 @@ kind_activity_map = {
     content_kinds.H5P: learning_activities.EXPLORE,
 }
 
+
 class Node(object):
     """Node: model to represent all nodes in the tree"""
 
@@ -503,7 +504,7 @@ class TreeNode(Node):
         if self.kind in kind_activity_map and not learning_activities:
             self.learning_activities = [kind_activity_map[self.kind]]
         else:
-            self.learning_activities = learning_activities
+            self.learning_activities = learning_activities or []
 
         self.accessibility_labels = accessibility_labels or []
         self.categories = categories or []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from ricecooker.classes.nodes import ChannelNode
 from ricecooker.classes.nodes import DocumentNode
 from ricecooker.classes.nodes import ExerciseNode
 from ricecooker.classes.nodes import HTML5AppNode
+from ricecooker.classes.nodes import kind_activity_map
 from ricecooker.classes.nodes import SlideshowNode
 from ricecooker.classes.nodes import TopicNode
 from ricecooker.classes.nodes import VideoNode
@@ -381,7 +382,12 @@ def video_data(contentnode_base_data, channel_domain_namespace, channel_node_id)
     video_data = copy.deepcopy(contentnode_base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     video_data.update(ids_dict)
-    video_data.update({"kind": content_kinds.VIDEO})
+    video_data.update(
+        {
+            "kind": content_kinds.VIDEO,
+            "learning_activities": [kind_activity_map.get(content_kinds.VIDEO)],
+        }
+    )
     return video_data
 
 
@@ -481,7 +487,12 @@ def audio_data(
     audio_data = copy.deepcopy(contentnode_base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     audio_data.update(ids_dict)
-    audio_data.update({"kind": content_kinds.AUDIO})
+    audio_data.update(
+        {
+            "kind": content_kinds.AUDIO,
+            "learning_activities": [kind_activity_map.get(content_kinds.AUDIO)],
+        }
+    )
     return audio_data
 
 
@@ -550,7 +561,12 @@ def document_data(
     document_data = copy.deepcopy(contentnode_base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     document_data.update(ids_dict)
-    document_data.update({"kind": content_kinds.DOCUMENT})
+    document_data.update(
+        {
+            "kind": content_kinds.DOCUMENT,
+            "learning_activities": [kind_activity_map.get(content_kinds.DOCUMENT)],
+        }
+    )
     return document_data
 
 
@@ -657,7 +673,12 @@ def html_data(
     html_data = copy.deepcopy(contentnode_base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     html_data.update(ids_dict)
-    html_data.update({"kind": content_kinds.HTML5})
+    html_data.update(
+        {
+            "kind": content_kinds.HTML5,
+            "learning_activities": [kind_activity_map.get(content_kinds.HTML5)],
+        }
+    )
     return html_data
 
 
@@ -739,6 +760,7 @@ def exercise_data(
             "kind": content_kinds.EXERCISE,
             "questions": [],
             "exercise_data": mastery_model,
+            "learning_activities": [kind_activity_map.get(content_kinds.EXERCISE)],
         }
     )
     return exercise_data
@@ -883,7 +905,12 @@ def slideshow_data(
     slideshow_data = copy.deepcopy(contentnode_base_data)
     ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
     slideshow_data.update(ids_dict)
-    slideshow_data.update({"kind": content_kinds.SLIDESHOW})
+    slideshow_data.update(
+        {
+            "kind": content_kinds.SLIDESHOW,
+            "learning_activities": [kind_activity_map.get(content_kinds.SLIDESHOW)],
+        }
+    )
     # TODO setup expected extra_fields['slideshow_data']
     return slideshow_data
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -11,6 +11,7 @@ from le_utils.constants import format_presets
 from le_utils.constants import licenses
 from le_utils.constants.labels import levels
 from le_utils.constants.languages import getlang
+from le_utils.constants.labels import learning_activities
 
 from ricecooker.classes.files import DocumentFile
 from ricecooker.classes.files import HTMLZipFile
@@ -24,10 +25,10 @@ from ricecooker.classes.nodes import DocumentNode
 from ricecooker.classes.nodes import RemoteContentNode
 from ricecooker.classes.nodes import SlideshowNode
 from ricecooker.classes.nodes import TopicNode
-from ricecooker.classes.nodes import TreeNode
 from ricecooker.exceptions import InvalidNodeException
 from ricecooker.utils.jsontrees import build_tree_from_json
 from ricecooker.utils.zip import create_predictable_zip
+
 
 """ *********** TOPIC FIXTURES *********** """
 
@@ -692,8 +693,15 @@ def test_remote_content_node_with_invalid_overridden_field():
 
 
 def test_default_learning_activities_in_tree_node():
-    from le_utils.constants import content_kinds
-    from le_utils.constants.labels import learning_activities
     node = DocumentNode(title="test", source_id="test", license=licenses.CC_BY)
     assert node.learning_activities == [learning_activities.READ]
 
+
+def test_no_default_learning_activities_in_tree_node_if_given():
+    node = DocumentNode(
+        title="test",
+        source_id="test",
+        license=licenses.CC_BY,
+        learning_activities=[learning_activities.WATCH]
+    )
+    assert node.learning_activities != [learning_activities.READ]

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -9,9 +9,9 @@ from le_utils.constants import content_kinds
 from le_utils.constants import file_types
 from le_utils.constants import format_presets
 from le_utils.constants import licenses
+from le_utils.constants.labels import learning_activities
 from le_utils.constants.labels import levels
 from le_utils.constants.languages import getlang
-from le_utils.constants.labels import learning_activities
 
 from ricecooker.classes.files import DocumentFile
 from ricecooker.classes.files import HTMLZipFile
@@ -702,6 +702,6 @@ def test_no_default_learning_activities_in_tree_node_if_given():
         title="test",
         source_id="test",
         license=licenses.CC_BY,
-        learning_activities=[learning_activities.WATCH]
+        learning_activities=[learning_activities.WATCH],
     )
     assert node.learning_activities != [learning_activities.READ]

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -24,6 +24,7 @@ from ricecooker.classes.nodes import DocumentNode
 from ricecooker.classes.nodes import RemoteContentNode
 from ricecooker.classes.nodes import SlideshowNode
 from ricecooker.classes.nodes import TopicNode
+from ricecooker.classes.nodes import TreeNode
 from ricecooker.exceptions import InvalidNodeException
 from ricecooker.utils.jsontrees import build_tree_from_json
 from ricecooker.utils.zip import create_predictable_zip
@@ -688,3 +689,11 @@ def test_remote_content_node_with_invalid_overridden_field():
             author="Such disallowed. Computer says no.",
         )
         node.validate_tree()
+
+
+def test_default_learning_activities_in_tree_node():
+    from le_utils.constants import content_kinds
+    from le_utils.constants.labels import learning_activities
+    node = DocumentNode(title="test", source_id="test", license=licenses.CC_BY)
+    assert node.learning_activities == [learning_activities.READ]
+


### PR DESCRIPTION
## Overview

In the TreeNode constructor, use [kind_activity_map](https://github.com/learningequality/kolibri/blob/release-v0.16.x/kolibri/core/content/constants/kind_to_learningactivity.py) borrowed from Kolibri to map the node's `kind` to a particular learning activity.

If `learning_activities` is provided to the constructor, then that is used. However, if it's not provided or is empty, then we refer to the map to provide a default learning activity.

Closes #451 

## Reviewer guidance

Are the two little tests sufficient? Any possible regressions?