### PR TITLE
Test under Python 3.11 & 3.12

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         include:
         - os: ubuntu-latest
           pippath: ~/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "filetype>=1.1.0",
         "urllib3==2.2.2",
     ],
-    python_requires=">=3.8, <3.11",
+    python_requires=">=3.8, <3.13",
     license="MIT license",
     zip_safe=False,
     keywords="ricecooker",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.{6,7,8,9,10}
+envlist = py3.{6,7,8,9,10,11,12}
 
 [testenv]
 basepython =
@@ -8,6 +8,8 @@ basepython =
     py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
+    py3.11: python3.11
+    py3.12: python3.12
 deps =
     -r{toxinidir}/requirements_test.txt
 setenv =


### PR DESCRIPTION
Build and test against Python 3.11 and 3.12

Tests pass locally
```
  py3.12: OK (56.96=setup[2.67]+cmd[54.29] seconds)
  congratulations :) (57.01 seconds)
```