### PR TITLE
Mock yt-dlp web requests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -462,8 +462,8 @@ def youtube_video_with_subs_dict():
 @pytest.fixture
 def audio_file():
     source_url = (
-        "https://ia800103.us.archive.org/9/items/cd_prince_prince/"
-        "disc1/02.%20Prince%20-%201999%20%28Edit%29_sample.mp3"
+        "https://ia800203.us.archive.org/26/items/Bach_Original_works_and_transcriptions-6556"
+        "/Felipe_Sarro_-_08_-_Bach_Sinfonia_11_BWV_797.mp3"
     )
     local_path = os.path.abspath(
         os.path.join(
@@ -477,7 +477,7 @@ def audio_file():
 
 @pytest.fixture
 def audio_filename():
-    return "c335e8044ecf583c690d5d8c65d68627.mp3"
+    return "7f78f74d9428d6394fb8a2fbd095965a.mp3"
 
 
 @pytest.fixture

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,4 +1,6 @@
 import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -34,9 +36,29 @@ def youtube_playlist_cache():
 
 
 def test_youtube_video_cache(youtube_video_cache):
-    video_info = youtube_video_cache.get_video_info(
-        use_proxy=False, get_subtitle_languages=True
-    )
+    mock_video_info = {
+        "artist": "JLRR",
+        "description": "Jamie Alexandre, Learning Equality's co-founder shares ....",
+        "ext": "mp4",
+        "id": "zzJLYK893gQ",
+        "kind": "video",
+        "license": "Creative Commons Attribution license (reuse allowed)",
+        "requested_subtitles": None,
+        "source_url": "https://www.youtube.com/watch?v=zzJLYK893gQ",
+        "subtitles": {},
+        "tags": [],
+        "thumbnail": "https://i.ytimg.com/vi/zzJLYK893gQ/maxresdefault.jpg",
+        "title": "Learning Equality's Pledge to UNESCO's Global Education Coalition",
+    }
+
+    with patch("ricecooker.utils.youtube.yt_dlp.YoutubeDL") as mock_youtube_dl_class:
+        mock_youtube_dl_instance = MagicMock()
+        mock_youtube_dl_class.return_value = mock_youtube_dl_instance
+        mock_youtube_dl_instance.extract_info.return_value = mock_video_info
+
+        video_info = youtube_video_cache.get_video_info(
+            use_proxy=False, get_subtitle_languages=True
+        )
     video_cache_filepath = os.path.abspath(
         os.path.join(
             os.path.dirname(__file__), "testcontent", "youtubecache", "test-video.json"


### PR DESCRIPTION
Use mocks to avoid tests doing requests to youtube that's filtering GitHub requests.
Closes: #522
