### PR TITLE
Upgrade flake8 hook for Python 3.12 compatibility.

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -26,7 +26,6 @@ jobs:
   unit_test:
     name: Python unit tests
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
@@ -43,7 +42,9 @@ jobs:
           pippath: ~\AppData\Local\pip\Cache
     steps:
     - uses: actions/checkout@v4
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
@@ -52,50 +53,52 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get install -y ffmpeg
         sudo apt-get install -y poppler-utils
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' && startsWith(matrix.os, 'ubuntu') }}
     - name: Cache Mac dependencies
       uses: actions/cache@v4
-      if: matrix.os == 'macos-13'
+      if: needs.pre_job.outputs.should_skip != 'true' && matrix.os == 'macos-13'
       with:
         path: ~/Library/Caches/Homebrew
         key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Install Mac dependencies
       run: brew install ffmpeg poppler
-      if: matrix.os == 'macos-13'
+      if: needs.pre_job.outputs.should_skip != 'true' && matrix.os == 'macos-13'
     - name: Windows dependencies cache
       id: windowscache
-      if: matrix.os == 'windows-latest'
+      if: needs.pre_job.outputs.should_skip != 'true' && matrix.os == 'windows-latest'
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}\tools
         key: ${{ runner.os }}-tools-${{ hashFiles('.github/workflows/pythontest.yml') }}
     - name: Download and unpack Windows dependencies
-      if: steps.cache.windowscache.cache-hit != 'true' && matrix.os == 'windows-latest'
+      if: needs.pre_job.outputs.should_skip != 'true' && steps.cache.windowscache.cache-hit != 'true' && matrix.os == 'windows-latest'
       run: |
         curl --output ffmpeg.zip -L https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip
         curl --output poppler.zip -L https://github.com/oschwartz10612/poppler-windows/releases/download/v21.11.0-0/Release-21.11.0-0.zip
         7z x ffmpeg.zip -otools -y
         7z x poppler.zip -otools -y
     - name: Set paths to Windows dependencies
-      if: matrix.os == 'windows-latest'
+      if: needs.pre_job.outputs.should_skip != 'true' && matrix.os == 'windows-latest'
       run: |
         echo "$pwd\tools\ffmpeg-master-latest-win64-gpl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$pwd\tools\poppler-21.11.0\Library\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Cache pip
-      if: ${{ !startsWith(runner.os, 'windows') }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' && !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v4
       with:
         path: ${{ matrix.pippath }}
         key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
     - name: Install tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
         pip install tox
     - name: tox env cache
-      if: ${{ !startsWith(runner.os, 'windows') }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' && !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
     - name: Test with tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e py${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
                 exclude: '^.+?\.template$'
                 additional_dependencies: ['click==8.0.4']
     -   repo: https://github.com/pycqa/flake8
-        rev: 4.0.1
+        rev: 7.1.1
         hooks:
             -   id: flake8
                 exclude: |


### PR DESCRIPTION
## Summary
Upgrades flake8 so that our linting checks work again, after ubuntu latest moved to Python 3.12 by default

Updates the skip check for Python tests, so that required checks show as passing even if the tests are being skipped.