### PR TITLE
Add webm support to compress_video. Add tests. Raise error if webm passed to faststart.

### DIFF
--- a/tests/media_utils/test_videos.py
+++ b/tests/media_utils/test_videos.py
@@ -251,6 +251,44 @@ class Test_compress_video:
             with pytest.raises(videos.VideoCompressionError):
                 videos.compress_video(bad_video.name, vout.name, overwrite=True)
 
+    def test_default_compression_works_webm(self, high_res_video_webm):
+        with TempFile(suffix=".webm") as vout:
+            videos.compress_video(high_res_video_webm.name, vout.name, overwrite=True)
+            width, height = get_resolution(vout.name)
+            assert height == 480, "should compress to 480 v resolution by default"
+
+    def test_compression_works_webm(self, high_res_video_webm):
+        with TempFile(suffix=".webm") as vout:
+            videos.compress_video(
+                high_res_video_webm.name, vout.name, overwrite=True, max_height=300
+            )
+            width, height = get_resolution(vout.name)
+            assert height == 300, "should be compress to 300 v resolution"
+
+    def test_compression_max_width_works_webm(self, high_res_video_webm):
+        with TempFile(suffix=".webm") as vout:
+            videos.compress_video(
+                high_res_video_webm.name, vout.name, overwrite=True, max_width=200
+            )
+            width, height = get_resolution(vout.name)
+            assert width == 200, "should be compress to 200 hz resolution"
+
+    def test_compression_format_conversion_to_webm(self, high_res_video):
+        with TempFile(suffix=".webm") as vout:
+            videos.compress_video(
+                high_res_video.name, vout.name, overwrite=True, max_height=300
+            )
+            width, height = get_resolution(vout.name)
+            assert height == 300, "should be compress to 300 v resolution"
+
+    def test_compression_webm_to_mp4_conversion(self, high_res_video_webm):
+        with TempFile(suffix=".mp4") as vout:
+            videos.compress_video(
+                high_res_video_webm.name, vout.name, overwrite=True, max_height=300
+            )
+            width, height = get_resolution(vout.name)
+            assert height == 300, "should be compress to 300 v resolution"
+
 
 class Test_convert_video:
     def test_convert_mov_works(self, high_res_mov_video):


### PR DESCRIPTION
## Summary
Adds support to our compress_video utility function for compressing webm videos (previously the use of mp4 specific flags would cause an error).
Makes the faststart flag function throw an error if used with webm, as webm does not have a faststart flag
Adds tests.