### PR TITLE
Fix the action not updating some data in the contributions tracking sheet

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,5 +1,7 @@
 name: Update community pull requests spreadsheet
-on: [pull_request_target, issue_comment]
+on:
+  pull_request_target:
+    types: [assigned,unassigned,opened,closed,reopened]
 
 jobs:
   call-update-spreadsheet:


### PR DESCRIPTION
## Summary

Fixes the spreadsheet's 'Assignees', 'Reviewers', and 'Merged' columns not being updated due to the action not being triggered.

Also removes `issue_comment` event since I don't need it anymore in the spreadsheet.

## Reviewer guidance

I tested that this fix works in the `test-actions` repo.
