### PR TITLE
Add vcr for youtube test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
             -   id: trailing-whitespace
             -   id: check-yaml
             -   id: check-added-large-files
+                exclude: '^tests/cassettes'
             -   id: debug-statements
             -   id: end-of-file-fixer
                 exclude: '^.+?\.json$'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,0 @@
-requests-cache==1.2.1
-pytest==8.3.4
-pycountry==24.6.1
-pytest-env==1.1.5
-mock==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,16 @@ setup(
         "filetype>=1.1.0",
         "urllib3==2.3.0",
     ],
+    extras_require={
+        "test": [
+            "requests-cache==1.2.1",
+            "pytest==8.3.4",
+            "pycountry==24.6.1",
+            "pytest-env==1.1.5",
+            "vcrpy==7.0.0; python_version >='3.10'",
+            "mock==5.1.0",
+        ],
+    },
     python_requires=">=3.9, <3.13",
     license="MIT license",
     zip_safe=False,

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -17,6 +17,7 @@ from le_utils.constants.exercises import GRAPHIE_DELIMITER
 from PIL import Image
 from requests import HTTPError
 from test_pdfutils import _save_file_url_to_path
+from vcr_config import my_vcr
 
 from ricecooker import config
 from ricecooker.classes.files import _ExerciseGraphieFile
@@ -744,7 +745,7 @@ def test_create_many_predictable_zip_files(ndirs=8193):
 """ *********** YOUTUBEVIDEOFILE TESTS *********** """
 
 
-@pytest.mark.skipif(True, reason="Requires connecting to youtube.")
+@my_vcr.use_cassette
 def test_youtubevideo_process_file(youtube_video_dict):
     video_file = YouTubeVideoFile(youtube_id=youtube_video_dict["youtube_id"])
     filename = video_file.process_file()

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -1,0 +1,17 @@
+import pytest
+
+try:
+    import vcr
+
+    my_vcr = vcr.VCR(
+        cassette_library_dir="tests/cassettes",
+        record_mode="new_episodes",
+        path_transformer=vcr.VCR.ensure_suffix(".yaml"),
+    )
+except ImportError:
+
+    class VCR:
+        def use_cassette(self, *args, **kwargs):
+            return pytest.mark.skip("vcrpy is not available on this Python version")
+
+    my_vcr = VCR()

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ basepython =
     py3.10: python3.10
     py3.11: python3.11
     py3.12: python3.12
-deps =
-    -r{toxinidir}/requirements_test.txt
+extras = test
 setenv =
     PYTHONPATH = {toxinidir}
 commands =


### PR DESCRIPTION
## Summary
* Adds the VCR library for testing
* Monkey patches to fix an extant issue in the library when kwargs are passed to the urllib3 response read method
* Moves all test requires specification into setup.py for ease of installation
* Turns the VCR use_cassette decorator instead into a pytest.mark.skip if vcr is unavailable (we can't install it on Python 3.9 as it requires an incompatible version of urllib3 there)

## References
This will allow us to test that https://github.com/learningequality/ricecooker/pull/573 doesn't break Youtube downloading
Also will allow for testing of future GDrive integration

## Reviewer guidance
Is this adequately documented?
Are tests passing?
