### PR TITLE
Revert "Allow for chefs to explicitly set a channel ID."

### DIFF
--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -362,7 +362,6 @@ class SushiChef(object):
                 source_id=self.channel_info["CHANNEL_SOURCE_ID"],
                 title=self.channel_info["CHANNEL_TITLE"],
                 tagline=self.channel_info.get("CHANNEL_TAGLINE"),
-                channel_id=self.channel_info.get("CHANNEL_ID"),
                 thumbnail=self.channel_info.get("CHANNEL_THUMBNAIL"),
                 language=self.channel_info.get("CHANNEL_LANGUAGE"),
                 description=self.channel_info.get("CHANNEL_DESCRIPTION"),

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -368,11 +368,8 @@ class ChannelNode(Node):
 
     kind = "Channel"
 
-    def __init__(
-        self, source_id, source_domain, tagline=None, channel_id=None, *args, **kwargs
-    ):
+    def __init__(self, source_id, source_domain, tagline=None, *args, **kwargs):
         # Map parameters to model variables
-        self.channel_id = channel_id
         self.source_domain = source_domain
         self.source_id = source_id
         self.tagline = tagline
@@ -407,7 +404,7 @@ class ChannelNode(Node):
         Returns: dict of channel data
         """
         return {
-            "id": self.channel_id or self.get_node_id().hex,
+            "id": self.get_node_id().hex,
             "name": self.title,
             "thumbnail": self.thumbnail.filename if self.thumbnail else None,
             "language": self.language,


### PR DESCRIPTION
## Summary
This reverts commit 9e394e721ab8bf9b904bd60bc8dba30c0d841901.
Reverts dangerous update that allows for node_id collisions across channels.