### PR TITLE
Fix placement of exception class to avoid breaking the channel manager.

### DIFF
--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -9,6 +9,12 @@ from requests.exceptions import RequestException
 from .. import config
 
 
+class InsufficientStorageException(Exception):
+    """Raised when there is not enough storage space."""
+
+    pass
+
+
 class ChannelManager:
     """Manager for handling channel tree structure and communicating to server
 
@@ -143,12 +149,6 @@ class ChannelManager:
                 )
                 if not exists
             ]
-
-
-class InsufficientStorageException(Exception):
-    """Raised when there is not enough storage space."""
-
-    pass
 
     def do_file_upload(self, filename):
         file_data = self.file_map[filename]


### PR DESCRIPTION
## Summary
* Poor code review by yours truly failed to notice that an exception class had been defined in the middle of the ChannelManager class, thus removing half of its methods.
* This moves it elsewhere to prevent this

## References
Fixes regression introduced by https://github.com/learningequality/ricecooker/pull/567
