### PR TITLE
Handle case where the file extension has changed from the original filename

### DIFF
--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -167,7 +167,7 @@ class InsufficientStorageException(Exception):
             # it does not currently use the passed in file_format as the default
             # extension.
             name, ext = os.path.splitext(data["name"])
-            if not ext:
+            if not ext or ext != data["file_format"]:
                 data["name"] = "{}.{}".format(name, data["file_format"])
             url_response = config.SESSION.post(config.get_upload_url(), json=data)
             if url_response.status_code == 412:


### PR DESCRIPTION
## Summary
* Studio ignores the file format we send and just uses the "filename" property to determine the appropriate extension for the file
* We already handled the case when the extension did not exist, this adds handling for when the file has been converted, so the original filename extension and the extension of the file we are uploading are totally different

See Slack discussion for more details: https://learningequality.slack.com/archives/C6S90FCDT/p1740676947066549