### PR TITLE
Allow ContentNode class to take a uri argument for its default file

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -195,7 +195,9 @@ class DownloadFile(File):
         self.validate()
         pipeline = config.FILE_PIPELINE or fallback_pipeline
         try:
-            metadata = pipeline.execute(self.path, context=self.context)[0]
+            metadata = pipeline.execute(
+                self.path, context=self.context, skip_cache=config.UPDATE
+            )[0]
             metadata = metadata.to_dict()
             for key in metadata:
                 if key == "path":

--- a/ricecooker/classes/licenses.py
+++ b/ricecooker/classes/licenses.py
@@ -52,12 +52,10 @@ class License(object):
     def validate(self):
         assert (
             not self.require_copyright_holder or self.copyright_holder != ""
-        ), "Assertion Failed: {} License requires a copyright holder".format(
-            self.license_id
-        )
+        ), "{} License requires a copyright holder".format(self.license_id)
         assert isinstance(
             self.copyright_holder, str
-        ), "Assertion Failed: Copyright holder must be a string"
+        ), "Copyright holder must be a string"
 
     def truncate_fields(self):
         if (

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -388,7 +388,7 @@ class Node(object):
             )
         self.license = license
 
-    def validate(self):  # noqa: C901
+    def _validate(self):  # noqa: C901
         """validate: Makes sure node is valid
         Args: None
         Returns: boolean indicating if node is valid
@@ -524,6 +524,11 @@ class Node(object):
 
         return True
 
+    def validate(self):
+        self.valid = False
+        self.valid = self._validate()
+        return self.valid
+
     def get_metadata_dict(self, metadata: dict[str, any]) -> dict[str, any]:
         """
         Supplements the metadata in the metadata dict argument with metadata from the node.
@@ -624,7 +629,7 @@ class ChannelNode(Node):
             ],
         }
 
-    def validate(self):
+    def _validate(self):
         """validate: Makes sure channel is valid
         Args: None
         Returns: boolean indicating if channel is valid
@@ -633,7 +638,7 @@ class ChannelNode(Node):
             not isinstance(self.source_domain, str), "Channel domain must be a string"
         )
         self._validate_values(self.language is None, "Channel must have a language")
-        return super(ChannelNode, self).validate()
+        return super(ChannelNode, self)._validate()
 
 
 class TreeNode(Node):
@@ -1011,7 +1016,7 @@ class VideoNode(ContentNode):
                 return ExtractedVideoThumbnailFile(storage_path)
         return None
 
-    def validate(self):
+    def _validate(self):
         """validate: Makes sure video is valid
         Args: None
         Returns: boolean indicating if video is valid
@@ -1289,7 +1294,7 @@ class ExerciseNode(ContentNode):
         self.extra_fields.update({"m": m_value})
         self.extra_fields.update({"n": n_value})
 
-    def validate(self):
+    def _validate(self):
         """validate: Makes sure exercise is valid
         Args: None
         Returns: boolean indicating if exercise is valid
@@ -1526,7 +1531,7 @@ class StudioContentNode(TreeNode):
             source_node_id or source_content_id, overriden_title, **kwargs
         )
 
-    def validate(self):
+    def _validate(self):
         if not self.source_channel_id:
             raise InvalidNodeException(
                 "Invalid node: source_channel_id must be specified, and be a valid UUID string."

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -277,7 +277,7 @@ def process_tree_files(tree):
     """
     # Fill in values necessary for next steps
     config.LOGGER.info("Processing content...")
-    files_to_diff = tree.process_tree(tree.channel)
+    files_to_diff = tree.process_tree()
     tree.check_for_files_failed()
     return files_to_diff, config.FAILED_FILES
 

--- a/ricecooker/utils/pipeline/__init__.py
+++ b/ricecooker/utils/pipeline/__init__.py
@@ -52,7 +52,12 @@ class FilePipeline(CompositeHandler):
         ExtractMetadataStageHandler,
     ]
 
-    def execute(self, path: str, context: Optional[Dict] = None) -> list[FileMetadata]:
+    def execute(
+        self,
+        path: str,
+        context: Optional[Dict] = None,
+        skip_cache: Optional[bool] = False,
+    ) -> list[FileMetadata]:
         """
         Execute the pipeline for a given file path.
         """
@@ -66,7 +71,9 @@ class FilePipeline(CompositeHandler):
                     scoped_context.update(file_metadata.to_dict())
                     # Execute the handler and get the new list of metadata
                     new_metadata_list = handler.execute(
-                        file_metadata.path, context=scoped_context
+                        file_metadata.path,
+                        context=scoped_context,
+                        skip_cache=skip_cache,
                     )
                     for new_metadata in new_metadata_list:
                         # For each new metadata in the returned list

--- a/ricecooker/utils/pipeline/__init__.py
+++ b/ricecooker/utils/pipeline/__init__.py
@@ -61,6 +61,7 @@ class FilePipeline(CompositeHandler):
         """
         Execute the pipeline for a given file path.
         """
+        context = context or {}
         file_metadata_list = [FileMetadata(path=path)]
         for handler in self._children:
             updated_file_metadata_list = []

--- a/ricecooker/utils/pipeline/context.py
+++ b/ricecooker/utils/pipeline/context.py
@@ -11,6 +11,42 @@ class AutoDataClassMetaClass(type):
 
 
 @dataclass
+class ContentNodeMetadata:
+    """
+    A dataclass for storing metadata about a content node.
+    """
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+    thumbnail: Optional[str] = None
+    license: Optional[str] = None
+    license_description: Optional[str] = None
+    author: Optional[str] = None
+    aggregator: Optional[str] = None
+    copyright_holder: Optional[str] = None
+    provider: Optional[str] = None
+    grade_levels: Optional[list[str]] = None
+    categories: Optional[list[str]] = None
+    resource_types: Optional[list[str]] = None
+    learning_activities: Optional[list[str]] = None
+    accessibility_labels: Optional[list[str]] = None
+    learner_needs: Optional[list[str]] = None
+    role: Optional[str] = None
+    source_id: Optional[str] = None
+    kind: Optional[str] = None
+    extra_fields: Optional[dict] = None
+
+
+def _recursive_update(target, source):
+    for k, v in source.items():
+        if k in target and isinstance(v, dict):
+            target[k] = _recursive_update(target[k], v)
+        else:
+            target[k] = v
+    return target
+
+
+@dataclass
 class FileMetadata:
     filename: Optional[str] = None
     path: Optional[str] = None
@@ -20,17 +56,19 @@ class FileMetadata:
     license: Optional[str] = None
     license_description: Optional[str] = None
     preset: Optional[str] = None
+    content_node_metadata: Optional[ContentNodeMetadata] = None
 
     def to_dict(self):
-        return {k: v for k, v in asdict(self).items() if v is not None}
+        return asdict(
+            self, dict_factory=lambda x: {k: v for k, v in x if v is not None}
+        )
 
     def merge(self, other):
         """
         Create a new FileMetadata object by the result of overwriting self
         fields with other fields when defined.
         """
-        new_dict = self.to_dict()
-        new_dict.update(other.to_dict())
+        new_dict = _recursive_update(self.to_dict(), other.to_dict())
         return self.__class__(**new_dict)
 
 

--- a/ricecooker/utils/pipeline/extract_metadata.py
+++ b/ricecooker/utils/pipeline/extract_metadata.py
@@ -3,6 +3,7 @@ from le_utils.constants import format_presets
 
 from .file_handler import ExtensionMatchingHandler
 from .file_handler import StageHandler
+from ricecooker.utils.pipeline.context import ContentNodeMetadata
 from ricecooker.utils.pipeline.context import FileMetadata
 from ricecooker.utils.utils import extract_path_ext
 from ricecooker.utils.videos import extract_duration_of_media
@@ -16,7 +17,10 @@ PRESETS_FROM_EXTENSIONS = {
     file_formats.H5P: format_presets.H5P_ZIP,
     file_formats.BLOOMPUB: format_presets.BLOOMPUB,
     file_formats.BLOOMD: format_presets.BLOOMPUB,
+    file_formats.HTML5: format_presets.HTML5_ZIP,
 }
+
+KIND_FROM_PRESET = {p.id: p.kind for p in format_presets.PRESETLIST}
 
 
 class MetadataExtractor(ExtensionMatchingHandler):
@@ -32,6 +36,12 @@ class MetadataExtractor(ExtensionMatchingHandler):
         preset = self.infer_preset(path)
         if preset:
             metadata["preset"] = preset
+            kind = KIND_FROM_PRESET.get(preset)
+            if kind:
+                metadata["content_node_metadata"] = metadata.get(
+                    "content_node_metadata", ContentNodeMetadata()
+                )
+                metadata["content_node_metadata"].kind = kind
         return FileMetadata(**metadata)
 
 
@@ -52,6 +62,10 @@ class EPUBMetadataExtractor(MetadataExtractor):
 
 class PDFMetadataExtractor(MetadataExtractor):
     EXTENSIONS = {file_formats.PDF}
+
+
+class HTML5MetadataExtractor(MetadataExtractor):
+    EXTENSIONS = {file_formats.HTML5}
 
 
 class H5PMetadataExtractor(MetadataExtractor):
@@ -76,6 +90,7 @@ class ExtractMetadataStageHandler(StageHandler):
         EPUBMetadataExtractor,
         PDFMetadataExtractor,
         H5PMetadataExtractor,
+        HTML5MetadataExtractor,
         BloomPubMetadataExtractor,
         VideoMetadataExtractor,
     ]

--- a/ricecooker/utils/pipeline/transfer.py
+++ b/ricecooker/utils/pipeline/transfer.py
@@ -400,8 +400,13 @@ class DownloadStageHandler(StageHandler):
             raise InvalidFileException(f"Could not handle download from {path}")
         return should_handle
 
-    def execute(self, path: str, context: Optional[Dict] = None) -> list[FileMetadata]:
-        metadata_list = super().execute(path, context=context)
+    def execute(
+        self,
+        path: str,
+        context: Optional[Dict] = None,
+        skip_cache: Optional[bool] = False,
+    ) -> list[FileMetadata]:
+        metadata_list = super().execute(path, context=context, skip_cache=skip_cache)
         if not metadata_list:
             # The download stage is special, as we expect it to always return a file
             # if it does not, we raise an exception to prevent further processing

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -57,16 +57,16 @@ def test_validate(
     # Content node validation
     pytest.raises(InvalidNodeException, contentnode_invalid_license.validate)
     pytest.raises(InvalidNodeException, contentnode_no_source_id.validate)
-    pytest.raises(InvalidNodeException, contentnode_invalid_files.validate)
+    pytest.raises(InvalidNodeException, contentnode_invalid_files.process_files)
     assert video.validate(), "Valid videos should pass validation"
-    pytest.raises(InvalidNodeException, video_invalid_files.validate)
+    pytest.raises(InvalidNodeException, video_invalid_files.process_files)
     assert audio.validate(), "Valid audio content should pass validation"
-    pytest.raises(InvalidNodeException, audio_invalid_files.validate)
+    pytest.raises(InvalidNodeException, audio_invalid_files.process_files)
     assert document.validate(), "Valid document content should pass validation"
-    pytest.raises(InvalidNodeException, document_invalid_files.validate)
+    pytest.raises(InvalidNodeException, document_invalid_files.process_files)
     assert html.validate(), "Valid html content should pass validation"
-    pytest.raises(InvalidNodeException, html_invalid_files.validate)
-    # pytest.raises(InvalidNodeException, html_invalid_zip.validate)  # TODO: implement index.html checking logic
+    pytest.raises(InvalidNodeException, html_invalid_files.process_files)
+    pytest.raises(InvalidNodeException, html_invalid_zip.process_files)
     assert exercise.validate(), "Valid html content should pass validation"
     pytest.raises(InvalidQuestionException, exercise_invalid_question.validate)
 

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -138,7 +138,7 @@ def test_exercise_extra_fields_string(exercise):
     # Make sure we throw an error if we have non-int strings
     exercise.extra_fields = {"mastery_model": exercises.M_OF_N, "m": "3.0", "n": "5.1"}
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNodeException):
         exercise.process_files()
 
     with pytest.raises(InvalidNodeException):
@@ -151,7 +151,7 @@ def test_exercise_extra_fields_string(exercise):
         "n": "five",
     }
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidNodeException):
         exercise.process_files()
 
     with pytest.raises(InvalidNodeException):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1324,7 +1324,11 @@ def test_html5_zip_cache_keys(mock_filecache, html_file):
     html = HTMLZipFile(path)
     html.process_file()
 
-    expected_keys = {f"DOWNLOAD:{path}", f"CONVERT:{html.filename}"}
+    expected_keys = {
+        f"DOWNLOAD:{path}",
+        f"CONVERT:{html.filename}",
+        f"EXTRACT_METADATA:{html.filename}",
+    }
     assert set(mock_filecache.cache.keys()) == expected_keys
 
 

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -9,14 +9,13 @@ from test_videos import _clear_ricecookerfilecache
 from test_videos import low_res_video  # noqa F401
 
 from ricecooker import config
-from ricecooker.classes.files import AudioFile
-from ricecooker.classes.files import DocumentFile
-from ricecooker.classes.files import EPubFile
-from ricecooker.classes.files import HTMLZipFile
+from ricecooker.classes.files import ExtractedEPubThumbnailFile
+from ricecooker.classes.files import ExtractedHTMLZipThumbnailFile
+from ricecooker.classes.files import ExtractedPdfThumbnailFile
+from ricecooker.classes.files import ExtractedVideoThumbnailFile
 from ricecooker.classes.files import ThumbnailFile
 from ricecooker.classes.files import TiledThumbnailFile
 from ricecooker.classes.files import VideoFile
-from ricecooker.classes.nodes import AudioNode
 from ricecooker.classes.nodes import DocumentNode
 from ricecooker.classes.nodes import HTML5AppNode
 from ricecooker.classes.nodes import TopicNode
@@ -255,111 +254,69 @@ class TestThumbnailGeneration(object):
     ############################################################################
 
     def test_non_existent_pdf_fails(self):
-        node = DocumentNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
         non_existent_path = "does/not/exist.pdf"
-        document_file = DocumentFile(non_existent_path, language="en")
-        node.add_file(document_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None (the non existent pdf)"
+        thumbnail_file = ExtractedPdfThumbnailFile(non_existent_path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for non-existent PDF"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_invalid_pdf_fails(self, invalid_document_file):
-        node = DocumentNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        node.add_file(invalid_document_file)
-        config.THUMBNAILS = True
-        node.process_files()
-        # assert filenames == [None], 'expected one None filename (the broken pdf)'
+        thumbnail_file = ExtractedPdfThumbnailFile(invalid_document_file.path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for invalid PDF"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_non_existent_epub_fails(self):
-        node = DocumentNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
         non_existent_path = "does/not/exist.epub"
-        document_file = EPubFile(non_existent_path, language="en")
-        node.add_file(document_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None (the non existent epub)"
+        thumbnail_file = ExtractedEPubThumbnailFile(non_existent_path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for non-existent EPUB"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_invalid_epub_fails(self, invalid_epub_file):
-        node = DocumentNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        node.add_file(invalid_epub_file)
-        config.THUMBNAILS = True
-        node.process_files()
-        # assert filenames == [None], 'expected one None filename (the broken epub)'  # TODO: implement epub deep validation
+        thumbnail_file = ExtractedEPubThumbnailFile(invalid_epub_file.path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for invalid EPUB"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_non_existent_htmlzip_fails(self):
-        node = HTML5AppNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
         non_existent_path = "does/not/exist.zip"
-        html_file = HTMLZipFile(non_existent_path, language="en")
-        node.add_file(html_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None filename (the broken zip)"
+        thumbnail_file = ExtractedHTMLZipThumbnailFile(non_existent_path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for non-existent HTML zip"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_invalid_htmlzip_fails(self, html_invalid_file):
-        node = DocumentNode(
-            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        node.add_file(html_invalid_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None filename (the broken html)"
-        assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        thumbnail_file = ExtractedHTMLZipThumbnailFile(html_invalid_file.path)
+        result = thumbnail_file.process_file()
 
-    def test_non_existent_mp3_fails(self):
-        node = AudioNode(
-            "audio-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        non_existent_path = "does/not/exist.mp3"
-        document_file = AudioFile(non_existent_path, language="en")
-        node.add_file(document_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None (the non existent mp3)"
+        assert result is None, "expected None result for invalid HTML zip"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
-
-    def test_invalid_mp3_fails(self, invalid_audio_file):
-        node = AudioNode(
-            "audio-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        node.add_file(invalid_audio_file)
-        config.THUMBNAILS = True
-        node.process_files()
-        # assert filenames == [None], 'expected one None filename (the broken mp3)'   # TODO: implement mp3 deep validation
-        # assert len(config.FAILED_FILES) == 1, 'expected one failed file'
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_non_existent_mp4_fails(self):
-        node = VideoNode(
-            "video-src-id", "Video", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
         non_existent_path = "does/not/exist.mp4"
-        document_file = VideoFile(non_existent_path, language="en")
-        node.add_file(document_file)
-        config.THUMBNAILS = True
-        filenames = node.process_files()
-        assert filenames == [None], "expected one None (the non existent mp4)"
+        thumbnail_file = ExtractedVideoThumbnailFile(non_existent_path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for non-existent MP4"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"
 
     def test_invalid_mp4_fails(self, invalid_video_file):
-        node = VideoNode(
-            "video-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
-        )
-        node.add_file(invalid_video_file)
-        config.THUMBNAILS = True
-        node.process_files()
-        # assert filenames == [None], 'expected one None filename (the broken mp4)'   # TODO: implement deep video validation
-        # assert len(config.FAILED_FILES) == 1, 'expected one failed file'
+        thumbnail_file = ExtractedVideoThumbnailFile(invalid_video_file.path)
+        result = thumbnail_file.process_file()
+
+        assert result is None, "expected None result for invalid MP4"
+        assert len(config.FAILED_FILES) == 1, "expected one failed file"
+        assert thumbnail_file.filename is None, "filename should remain None"

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,8 +1,10 @@
 """ Tests for tree construction """
-import copy
 import os
 import tempfile
 import uuid
+from unittest.mock import MagicMock
+from unittest.mock import mock_open
+from unittest.mock import patch
 
 import pytest
 from le_utils.constants import content_kinds
@@ -33,6 +35,8 @@ from ricecooker.classes.nodes import SlideshowNode
 from ricecooker.classes.nodes import TopicNode
 from ricecooker.classes.nodes import TreeNode
 from ricecooker.exceptions import InvalidNodeException
+from ricecooker.managers.tree import ChannelManager
+from ricecooker.managers.tree import InsufficientStorageException
 from ricecooker.utils.jsontrees import build_tree_from_json
 from ricecooker.utils.pipeline import FilePipeline
 from ricecooker.utils.zip import create_predictable_zip
@@ -152,15 +156,6 @@ def invalid_tree(invalid_channel, invalid_topic, invalid_document):
     return invalid_channel
 
 
-@pytest.fixture
-def invalid_tree_2(channel, topic, invalid_document):
-    channel_copy = copy.deepcopy(channel)
-    topic_copy = copy.deepcopy(topic)
-    topic_copy.add_child(invalid_document)
-    channel_copy.add_child(topic_copy)
-    return channel_copy
-
-
 """ *********** CONTENT NODE TESTS *********** """
 
 
@@ -250,18 +245,12 @@ def test_licenses(channel, topic, document, license_name, copyright_holder):
     assert not topic.license, "Topic should not have a license"
 
 
-def test_validate_tree(tree, invalid_tree, invalid_tree_2):
-    assert tree.validate_tree(), "Valid tree should pass validation"
+def test_validate_topics(tree, invalid_tree):
+    assert tree.validate(), "Valid topic should pass validation"
 
     try:
-        invalid_tree.validate_tree()
-        assert False, "Invalid tree should fail validation"
-    except InvalidNodeException:
-        pass
-
-    try:
-        invalid_tree_2.validate_tree()
-        assert False, "Invalid tree should fail validation"
+        invalid_tree.validate()
+        assert False, "Invalid topic should fail validation"
     except InvalidNodeException:
         pass
 
@@ -339,7 +328,7 @@ def test_add_files_with_preset(channel):
     parent_node = build_tree_from_json(channel, [topic_node])
     topic_node = parent_node.children[0]
     html5_node = topic_node.children[0]
-    assert parent_node.validate_tree()
+    assert parent_node.validate()
     assert parent_node
     assert parent_node.children[0]
     assert topic_node.kind == "topic"
@@ -395,7 +384,7 @@ def test_slideshow_node_via_files(channel):
     assert "slideshow_data" in slideshow_node.extra_fields, "missing slideshow_data key"
     slideshow_node.process_files()
     channel.add_child(slideshow_node)
-    assert channel.validate_tree()
+    assert channel.validate()
     assert slideshow_node.to_dict()  # not ready yet bcs needs ot be part of tree...
 
 
@@ -433,7 +422,7 @@ def test_slideshow_node_via_add_file(channel):
     assert len(slideshow_node.files) == 3, "missing files"
 
     channel.add_child(slideshow_node)
-    assert channel.validate_tree()
+    assert channel.validate()
 
 
 """ *********** CUSTOM NAVIGATION CONTENT NODE TESTS *********** """
@@ -471,7 +460,7 @@ def test_custom_navigation_node_via_files(channel):
     ), "missing custom navigation modality"
     custom_navigation_node.process_files()
     channel.add_child(custom_navigation_node)
-    assert channel.validate_tree()
+    assert channel.validate()
     assert custom_navigation_node.to_dict()
 
 
@@ -508,7 +497,7 @@ def test_custom_navigation_node_via_add_file(channel):
     ), "missing custom navigation modality"
     custom_navigation_node.process_files()
     channel.add_child(custom_navigation_node)
-    assert channel.validate_tree()
+    assert channel.validate()
     assert custom_navigation_node.to_dict()
 
 
@@ -544,7 +533,7 @@ def test_custom_navigation_channel_node_via_files():
     ), "missing custom navigation modality"
     custom_navigation_channel_node.set_thumbnail(thumbimg1)
     custom_navigation_channel_node.process_files()
-    assert custom_navigation_channel_node.validate_tree()
+    assert custom_navigation_channel_node.validate()
     assert custom_navigation_channel_node.to_dict()
     assert custom_navigation_channel_node.to_dict()["thumbnail"] == thumbimg1.filename
     assert len(custom_navigation_channel_node.to_dict()["files"]) == 1
@@ -586,7 +575,7 @@ def test_custom_navigation_channel_node_via_add_file():
     ), "missing custom navigation modality"
     custom_navigation_channel_node.set_thumbnail(thumbimg1)
     custom_navigation_channel_node.process_files()
-    assert custom_navigation_channel_node.validate_tree()
+    assert custom_navigation_channel_node.validate()
     assert custom_navigation_channel_node.to_dict()
     assert custom_navigation_channel_node.to_dict()["thumbnail"] == thumbimg1.filename
     assert len(custom_navigation_channel_node.to_dict()["files"]) == 1
@@ -605,7 +594,7 @@ def test_remote_content_node_with_no_overrides():
     assert remote_content_node
     assert remote_content_node.kind == "remotecontent"
     assert len(remote_content_node.files) == 0
-    assert remote_content_node.validate_tree()
+    assert remote_content_node.validate()
     output = remote_content_node.to_dict()
     assert output.get("title") is None
     assert output.get("description") is None
@@ -621,7 +610,7 @@ def test_remote_content_node_with_basic_overrides():
     assert remote_content_node
     assert remote_content_node.kind == "remotecontent"
     assert len(remote_content_node.files) == 0
-    assert remote_content_node.validate_tree()
+    assert remote_content_node.validate()
     output = remote_content_node.to_dict()
     assert output.get("title") == "My Title"
     assert output.get("description") == "My Description"
@@ -636,7 +625,7 @@ def test_remote_content_node_with_provider_override():
     assert remote_content_node
     assert remote_content_node.kind == "remotecontent"
     assert len(remote_content_node.files) == 0
-    assert remote_content_node.validate_tree()
+    assert remote_content_node.validate()
     output = remote_content_node.to_dict()
     assert output.get("provider") == "Doctor Tibbles"
 
@@ -647,7 +636,7 @@ def test_remote_content_node_with_bad_channel_id():
             "a" * 4,
             source_node_id="b" * 32,
         )
-        node.validate_tree()
+        node.validate()
 
 
 def test_remote_content_node_with_bad_source_content_node_ids():
@@ -657,7 +646,7 @@ def test_remote_content_node_with_bad_source_content_node_ids():
             source_node_id="b" * 4,
             source_content_id="c" * 4,
         )
-        node.validate_tree()
+        node.validate()
 
 
 def test_remote_content_node_with_overridden_thumbnail():
@@ -670,7 +659,7 @@ def test_remote_content_node_with_overridden_thumbnail():
         thumbnail=thumbimg1,
     )
     assert len(remote_content_node.files) == 1
-    assert remote_content_node.validate_tree()
+    assert remote_content_node.validate()
     remote_content_node.process_files()
     output = remote_content_node.to_dict()
     assert output.get("files")[0]["filename"] == "d7ab03e4263fc374737d96ac2da156c1.jpg"
@@ -685,7 +674,7 @@ def test_remote_content_node_with_overridden_grade_levels():
     )
     assert remote_content_node
     assert remote_content_node.kind == "remotecontent"
-    assert remote_content_node.validate_tree()
+    assert remote_content_node.validate()
     output = remote_content_node.to_dict()
     assert output.get("grade_levels") == grades
 
@@ -697,7 +686,7 @@ def test_remote_content_node_with_invalid_overridden_field():
             source_content_id="c" * 32,
             author="Such disallowed. Computer says no.",
         )
-        node.validate_tree()
+        node.validate()
 
 
 def test_default_learning_activities_in_tree_node():
@@ -1018,3 +1007,266 @@ def test_set_metadata_from_ancestors_hierarchical_labels_inheritance():
     # Should inherit all learner needs
     assert needs.PEOPLE in node.learner_needs
     assert needs.MATERIALS in node.learner_needs
+
+
+# Tests below generated using Claude 3.7 Sonnet
+
+
+def test_validate_node_sets_error_attribute(channel):
+    """Test that validate_node sets the _error attribute when InvalidNodeException occurs."""
+    # Create a manager
+    manager = ChannelManager(channel)
+
+    # Create a mock node that will raise InvalidNodeException when validate is called
+    mock_node = MagicMock()
+    mock_node.validate.side_effect = InvalidNodeException("Test validation error")
+
+    # Call validate_node with STRICT=False
+    with patch("ricecooker.config.STRICT", False):
+        result = manager.validate_node(mock_node)
+
+    # Check that _error was set and validate returned True
+    assert hasattr(mock_node, "_error")
+    assert mock_node._error == "Test validation error"
+    assert result is True
+
+
+def test_process_node_handles_exceptions(channel):
+    """Test that process_node handles InvalidNodeException and ValueError."""
+    # Create a manager
+    manager = ChannelManager(channel)
+
+    # Create a mock node that will raise InvalidNodeException when process_files is called
+    mock_node = MagicMock()
+    mock_node.files = []
+    mock_node.process_files.side_effect = InvalidNodeException("Test process error")
+
+    # Call process_node with STRICT=False
+    with patch("ricecooker.config.STRICT", False):
+        result = manager.process_node(mock_node)
+
+    # Check that _error was set and process_node returned an empty dict
+    assert hasattr(mock_node, "_error")
+    assert mock_node._error == "Test process error"
+    assert result == {}
+
+    # Now test with ValueError
+    mock_node = MagicMock()
+    mock_node.files = []
+    mock_node.process_files.side_effect = ValueError("Test value error")
+
+    # Call process_node with STRICT=False
+    with patch("ricecooker.config.STRICT", False):
+        result = manager.process_node(mock_node)
+
+    # Check that _error was set and process_node returned an empty dict
+    assert hasattr(mock_node, "_error")
+    assert mock_node._error == "Test value error"
+    assert result == {}
+
+
+def test_add_nodes_skips_invalid_nodes(channel):
+    """Test that add_nodes skips invalid nodes and registers them as failed builds."""
+    # Create a manager
+    manager = ChannelManager(channel)
+    manager.node_count_dict = {"upload_count": 0, "total_count": 10}
+
+    # Create a valid child node
+    valid_child = MagicMock()
+    valid_child.valid = True
+    valid_child.to_dict.return_value = {"id": "valid_id", "title": "Valid Node"}
+    valid_child.get_node_id().hex = "valid_hex"
+
+    # Create an invalid child node
+    invalid_child = MagicMock()
+    invalid_child.valid = False
+    invalid_child.source_id = "invalid_source_id"
+    invalid_child._error = "Test validation error"
+    invalid_child.files = []
+    invalid_child.get_node_id = MagicMock()
+    invalid_child.get_node_id().hex = "invalid_hex"
+
+    # Create a parent node with both children
+    parent_node = MagicMock()
+    parent_node.title = "Parent"
+    parent_node.children = [valid_child, invalid_child]
+
+    # Mock the session post response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response._content = '{"root_ids": {"valid_hex": "new_root_id"}}'.encode(
+        "utf-8"
+    )
+
+    # Call add_nodes
+    with patch("ricecooker.config.SESSION.post", return_value=mock_response):
+        manager.add_nodes("root_id", parent_node)
+
+    # Check that the invalid node was added to failed_node_builds using its node_id.hex
+    assert "invalid_hex" in manager.failed_node_builds
+    assert manager.failed_node_builds["invalid_hex"]["node"] == invalid_child
+    assert "Test validation error" in manager.failed_node_builds["invalid_hex"]["error"]
+
+    # Check that only the valid node was included in the payload
+    valid_child.to_dict.assert_called_once()  # valid node's to_dict was called
+    invalid_child.to_dict.assert_not_called()  # invalid node's to_dict was not called
+
+
+def test_add_nodes_handles_connection_error(channel):
+    """Test that add_nodes handles ConnectionError."""
+    # Create a manager
+    manager = ChannelManager(channel)
+    manager.node_count_dict = {"upload_count": 0, "total_count": 10}
+
+    # Create a valid child node
+    valid_child = MagicMock()
+    valid_child.valid = True
+    valid_child.to_dict.return_value = {"id": "valid_id", "title": "Valid Node"}
+
+    # Create a parent node with the child
+    parent_node = MagicMock()
+    parent_node.title = "Parent"
+    parent_node.children = [valid_child]
+
+    # Mock the session post to raise ConnectionError
+    with patch(
+        "ricecooker.config.SESSION.post",
+        side_effect=ConnectionError("Connection refused"),
+    ):
+        manager.add_nodes("root_id", parent_node)
+
+    # Check that the error was registered in failed_node_builds
+    assert "root_id" in manager.failed_node_builds
+    assert manager.failed_node_builds["root_id"]["node"] == parent_node
+    assert isinstance(manager.failed_node_builds["root_id"]["error"], ConnectionError)
+
+
+def test_add_nodes_handles_server_error(channel):
+    """Test that add_nodes handles server error responses."""
+    # Create a manager
+    manager = ChannelManager(channel)
+    manager.node_count_dict = {"upload_count": 0, "total_count": 10}
+
+    # Create a valid child node
+    valid_child = MagicMock()
+    valid_child.valid = True
+    valid_child.to_dict.return_value = {"id": "valid_id", "title": "Valid Node"}
+
+    # Create a parent node with the child
+    parent_node = MagicMock()
+    parent_node.title = "Parent"
+    parent_node.children = [valid_child]
+
+    # Mock the session post to return a 500 error
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.reason = "Internal Server Error"
+    mock_response.content = b"Server error"
+
+    with patch("ricecooker.config.SESSION.post", return_value=mock_response):
+        manager.add_nodes("root_id", parent_node)
+
+    # Check that the error was registered in failed_node_builds
+    assert "root_id" in manager.failed_node_builds
+    assert manager.failed_node_builds["root_id"]["node"] == parent_node
+    assert manager.failed_node_builds["root_id"]["error"] == "Internal Server Error"
+    assert manager.failed_node_builds["root_id"]["content"] == b"Server error"
+
+
+def test_file_upload_insufficient_storage(channel):
+    """Test that do_file_upload raises InsufficientStorageException on 412 response."""
+    # Create a manager
+    manager = ChannelManager(channel)
+
+    # Mock file_map, get_storage_path, and file open
+    filename = "test_file.mp4"
+    file_data = MagicMock()
+    file_data.skip_upload = False
+    file_data.size = 1024
+    file_data.checksum = "abcdef1234567890"
+    file_data.original_filename = None
+    file_data.get_filename.return_value = filename
+    file_data.extension = "mp4"
+    file_data.get_preset.return_value = "video"
+    file_data.duration = 60
+
+    manager.file_map = {filename: file_data}
+
+    # Mock the open call
+    mocked_open = mock_open(read_data=b"test file content")
+
+    # Mock the session post to return a 412 error
+    mock_response = MagicMock()
+    mock_response.status_code = 412
+
+    with patch("builtins.open", mocked_open), patch(
+        "ricecooker.config.get_storage_path", return_value="/tmp/test_file.mp4"
+    ), patch("ricecooker.config.SESSION.post", return_value=mock_response):
+
+        # Check that InsufficientStorageException is raised
+        with pytest.raises(
+            InsufficientStorageException, match="You have run out of storage space."
+        ):
+            manager.do_file_upload(filename)
+
+
+def test_add_nodes_checks_both_failed_files_and_validity(channel):
+    """Test that add_nodes checks both for failed files and node validity."""
+    # Create a manager
+    manager = ChannelManager(channel)
+    manager.node_count_dict = {"upload_count": 0, "total_count": 10}
+
+    # Create three types of nodes:
+    # 1. Valid node with no failed files
+    valid_node = MagicMock()
+    valid_node.valid = True
+    valid_node.files = []
+    valid_node.to_dict.return_value = {"id": "valid"}
+    valid_node.get_node_id = MagicMock()
+    valid_node.get_node_id().hex = "valid-hex"
+
+    # 2. Valid node with a failed file
+    node_with_failed_file = MagicMock()
+    node_with_failed_file.valid = True
+    failed_file = MagicMock()
+    failed_file.is_primary = True
+    failed_file.filename = None  # Failed to download
+    node_with_failed_file.files = [failed_file]
+    node_with_failed_file.get_node_id = MagicMock()
+    node_with_failed_file.get_node_id().hex = "failed-file-hex"
+
+    # 3. Invalid node with no failed files
+    invalid_node = MagicMock()
+    invalid_node.valid = False
+    invalid_node.files = []
+    invalid_node.get_node_id = MagicMock()
+    invalid_node.get_node_id().hex = "invalid-hex"
+    invalid_node._error = "Validation error"
+
+    # Create parent with all test nodes
+    parent_node = MagicMock()
+    parent_node.title = "Parent"
+    parent_node.children = [valid_node, node_with_failed_file, invalid_node]
+
+    # Mock the session post response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response._content = '{"root_ids": {"valid-hex": "new-root-id"}}'.encode(
+        "utf-8"
+    )
+
+    # Call add_nodes
+    with patch("ricecooker.config.SESSION.post", return_value=mock_response):
+        manager.add_nodes("root_id", parent_node)
+
+    # Check that both types of failed nodes were registered in failed_node_builds
+    assert "failed-file-hex" in manager.failed_node_builds  # Node with failed file
+    assert "invalid-hex" in manager.failed_node_builds  # Invalid node
+
+    # Check that only the valid node was included in the payload
+    valid_node.to_dict.assert_called_once()
+    node_with_failed_file.to_dict.assert_not_called()
+    invalid_node.to_dict.assert_not_called()
+
+
+# End generated tests

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -19,6 +19,7 @@ from ricecooker.classes.files import SlideImageFile
 from ricecooker.classes.files import ThumbnailFile
 from ricecooker.classes.licenses import get_license
 from ricecooker.classes.licenses import License
+from ricecooker.classes.nodes import ContentNode
 from ricecooker.classes.nodes import CustomNavigationChannelNode
 from ricecooker.classes.nodes import CustomNavigationNode
 from ricecooker.classes.nodes import DocumentNode
@@ -27,6 +28,7 @@ from ricecooker.classes.nodes import SlideshowNode
 from ricecooker.classes.nodes import TopicNode
 from ricecooker.exceptions import InvalidNodeException
 from ricecooker.utils.jsontrees import build_tree_from_json
+from ricecooker.utils.pipeline import FilePipeline
 from ricecooker.utils.zip import create_predictable_zip
 
 
@@ -694,6 +696,7 @@ def test_remote_content_node_with_invalid_overridden_field():
 
 def test_default_learning_activities_in_tree_node():
     node = DocumentNode(title="test", source_id="test", license=licenses.CC_BY)
+    node.infer_learning_activities()
     assert node.learning_activities == [learning_activities.READ]
 
 
@@ -705,3 +708,73 @@ def test_no_default_learning_activities_in_tree_node_if_given():
         learning_activities=[learning_activities.WATCH],
     )
     assert node.learning_activities != [learning_activities.READ]
+
+
+def test_automatic_resource_node_video(video_file):
+    node = ContentNode(
+        "test",
+        "test",
+        licenses.CC_BY,
+        uri=video_file.path,
+        pipeline=FilePipeline(),
+        copyright_holder="Demo Holdings",
+    )
+    node.process_files()
+    assert node.kind == content_kinds.VIDEO
+    assert node.learning_activities == [learning_activities.WATCH]
+
+
+def test_automatic_resource_node_audio(audio_file):
+    node = ContentNode(
+        "test",
+        "test",
+        licenses.CC_BY,
+        uri=audio_file.path,
+        pipeline=FilePipeline(),
+        copyright_holder="Demo Holdings",
+    )
+    node.process_files()
+    assert node.kind == content_kinds.AUDIO
+    assert node.learning_activities == [learning_activities.LISTEN]
+
+
+def test_automatic_resource_node_document(document_file):
+    node = ContentNode(
+        "test",
+        "test",
+        licenses.CC_BY,
+        uri=document_file.path,
+        pipeline=FilePipeline(),
+        copyright_holder="Demo Holdings",
+    )
+    node.process_files()
+    assert node.kind == content_kinds.DOCUMENT
+    assert node.learning_activities == [learning_activities.READ]
+
+
+def test_automatic_resource_node_epub(epub_file):
+    node = ContentNode(
+        "test",
+        "test",
+        licenses.CC_BY,
+        uri=epub_file.path,
+        pipeline=FilePipeline(),
+        copyright_holder="Demo Holdings",
+    )
+    node.process_files()
+    assert node.kind == content_kinds.DOCUMENT
+    assert node.learning_activities == [learning_activities.READ]
+
+
+def test_automatic_resource_node_html5(html_file):
+    node = ContentNode(
+        "test",
+        "test",
+        licenses.CC_BY,
+        uri=html_file.path,
+        pipeline=FilePipeline(),
+        copyright_holder="Demo Holdings",
+    )
+    node.process_files()
+    assert node.kind == content_kinds.HTML5
+    assert node.learning_activities == [learning_activities.EXPLORE]


### PR DESCRIPTION
## Summary
* Updates the ContentNode class to allow just passing a URI for the resource, which will then infer the kind, files etc to make the node
* Updates pipeline metadata extraction to infer kind for an associated content node
* Cleans up ContentNode behaviour to allow deferred setting of the kind

## References
Part of #558


## Reviewer guidance
Do tests cover the appropriate code paths? Are they missing anything? Does the code make sense?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for processing content nodes using a pipeline with URI-based file handling.
  - Content nodes now automatically infer their type and learning activities based on the resource file type.
  - Enhanced metadata extraction for HTML5 files, including kind inference and metadata merging.
  - Introduced comprehensive metadata inheritance and validation across node hierarchies.
  - Added new metadata fields and improved license serialization and validation.
  - Unified file preset handling with default presets and improved thumbnail file format associations.
  - Added explicit error handling to remove invalid nodes during validation and processing.
  - Enabled optional cache skipping in pipeline and file handling stages for more flexible processing.

- **Bug Fixes**
  - Improved handling of context initialization in file pipelines to prevent errors when context is not provided.
  - Enhanced error messages for file preset retrieval and improved pipeline execution with optional cache skipping.
  - Fixed license validation error messages to be clearer and simplified cache usage control in file handling.

- **Tests**
  - Added tests to verify automatic kind and learning activity inference for various file types.
  - Updated tests to check for new cache keys related to HTML5 metadata extraction.
  - Added tests for metadata inheritance and merging in node hierarchies.
  - Updated tests to expect exceptions during file processing rather than validation for invalid content nodes.
  - Refactored thumbnail failure tests to focus on thumbnail file processing directly.
  - Updated exercise tests to expect consistent exception types for invalid extra field values.
  - Added tests covering robust error handling in node validation, processing, and upload management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->