### PR TITLE
Fix header set for the DOWNLOAD_SESSION

### DIFF
--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -39,7 +39,7 @@ def uploadchannel(  # noqa: C901
     publish=False,
     compress=False,
     stage=False,
-    **kwargs
+    **kwargs,
 ):
     """uploadchannel: Upload channel to Kolibri Studio
     Args:
@@ -83,9 +83,9 @@ def uploadchannel(  # noqa: C901
         # Authenticate user and check current Ricecooker version
         username, token = authenticate_user(token)
         config.LOGGER.info("Logged in with username {0}".format(username))
-        config.DOWNLOAD_SESSION.headers.update({
-            "User-Agent": f"Ricecooker/{__version__} bot ({username})"
-        })
+        config.DOWNLOAD_SESSION.headers.update(
+            {"User-Agent": f"Ricecooker/{__version__} bot ({username})"}
+        )
         check_version_number()
     else:
         username = ""

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -301,6 +301,7 @@ def upload_files(tree, file_diff):
         file_diff ([str]): list of files to upload
     Returns: None
     """
+    # Upload new files to CC
     config.LOGGER.info(
         "  Uploading {0} new file(s) to Kolibri Studio...".format(len(file_diff))
     )
@@ -315,6 +316,7 @@ def create_tree(tree):
         tree (ChannelManager): manager to handle communication to Kolibri Studio
     Returns: channel id of created channel and link to channel
     """
+    # Create tree
     config.LOGGER.info("Creating tree on Kolibri Studio...")
     channel_id, channel_link = tree.upload_tree()
     return channel_link, channel_id
@@ -345,8 +347,10 @@ def select_sample_nodes(channel, size=10, seed=42):  # noqa: C901
         for child in subtree.children:
             child_path = parents_path + (child,)
             if child.children:
+                # recurse
                 walk_tree(child_path, child)
             else:
+                # emit leaf node
                 node_paths.append(child_path)
 
     walk_tree((), channel)
@@ -371,6 +375,7 @@ def select_sample_nodes(channel, size=10, seed=42):  # noqa: C901
 
     def attach(parent, node_path):
         if len(node_path) == 1:
+            # leaf node
             parent.add_child(node_path[0])
         else:
             child = node_path[0]

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -321,7 +321,7 @@ def create_tree(tree):
 
 
 def publish_tree(tree, channel_id):
-    """publish_tree: Publish tree to Kolibri 
+    """publish_tree: Publish tree to Kolibri
     Args:
         tree (ChannelManager): manager to handle communication to Kolibri Studio
         channel_id (str): id of channel to publish
@@ -382,4 +382,3 @@ def select_sample_nodes(channel, size=10, seed=42):  # noqa: C901
         attach(channel_sample, node_path)
 
     return channel_sample
-

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -240,7 +240,7 @@ def check_version_number():
 def prompt_yes_or_no(message):
     """prompt_yes_or_no: Prompt user to reply with a y/n response
     Args: None
-    Returns: bool indicating user response
+    Returns: None
     """
     user_input = input("{} [y/n]:".format(message)).lower()
     if user_input.startswith("y"):
@@ -283,11 +283,12 @@ def process_tree_files(tree):
 
 
 def get_file_diff(tree, files_to_diff):
-    """get_file_diff: Determine which files have not been uploaded to Kolibri Studio
+    """get_file_diff: Download files from nodes
     Args:
         tree (ChannelManager): manager to handle communication to Kolibri Studio
     Returns: list of files that are not on Kolibri Studio
     """
+    # Determine which files have not yet been uploaded to the CC server
     config.LOGGER.info("  Checking if files exist on Kolibri Studio...")
     file_diff = tree.get_file_diff(files_to_diff)
     return file_diff
@@ -298,7 +299,7 @@ def upload_files(tree, file_diff):
     Args:
         tree (ChannelManager): manager to handle communication to Kolibri Studio
         file_diff ([str]): list of files to upload
-    Returns: list of files that were uploaded
+    Returns: None
     """
     config.LOGGER.info(
         "  Uploading {0} new file(s) to Kolibri Studio...".format(len(file_diff))
@@ -312,7 +313,7 @@ def create_tree(tree):
     """create_tree: Upload tree to Kolibri Studio
     Args:
         tree (ChannelManager): manager to handle communication to Kolibri Studio
-    Returns: tuple of (channel link, channel id)
+    Returns: channel id of created channel and link to channel
     """
     config.LOGGER.info("Creating tree on Kolibri Studio...")
     channel_id, channel_link = tree.upload_tree()
@@ -320,7 +321,7 @@ def create_tree(tree):
 
 
 def publish_tree(tree, channel_id):
-    """publish_tree: Publish tree to Kolibri Studio
+    """publish_tree: Publish tree to Kolibri 
     Args:
         tree (ChannelManager): manager to handle communication to Kolibri Studio
         channel_id (str): id of channel to publish


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR ensures that all download requests made by the DOWNLOAD_SESSION in the ricecooker project include a properly formatted User-Agent header. The header follows the format: Ricecooker/{version} bot ({username}), aligning with Wikimedia's User-Agent policy.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses  #483

##Manual Verification Steps
- Executed a test script that sends a request to https://httpbin.org using the configured DOWNLOAD_SESSION.
- Verified that the response includes the correct User-Agent header:

![WhatsApp Image 2025-04-14 at 17 16 22_9c00d1b4](https://github.com/user-attachments/assets/dcf3ec0f-b3ae-40a9-b487-06bfeb756157)

- Confirmed that the header is correctly set for all download requests.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…
