### PR TITLE
Remove reliance on le-utils based pycountry using getlang methods.

### DIFF
--- a/ricecooker/utils/pipeline/convert.py
+++ b/ricecooker/utils/pipeline/convert.py
@@ -528,10 +528,11 @@ class SubtitleConversionHandler(ExtensionMatchingHandler):
 
         # Language is not present, let's try different codes
         if not converter.has_language(language):
+            input_language = get_language_with_alpha2_fallback(language)
             for lang_code in converter.get_language_codes():
-                language = get_language_with_alpha2_fallback(lang_code)
+                lang_obj = get_language_with_alpha2_fallback(lang_code)
 
-                if language and language.code == language:
+                if lang_obj and lang_obj.code == input_language.code:
                     convert_lang_code = lang_code
                     break
             else:

--- a/ricecooker/utils/pipeline/convert.py
+++ b/ricecooker/utils/pipeline/convert.py
@@ -22,7 +22,6 @@ import html5lib
 from html5lib.html5parser import ParseError
 from le_utils.constants import file_formats
 from le_utils.constants import format_presets
-from le_utils.constants import languages
 from PIL import Image
 from PIL import UnidentifiedImageError
 
@@ -43,6 +42,7 @@ from ricecooker.utils.utils import extract_path_ext
 from ricecooker.utils.videos import compress_video
 from ricecooker.utils.videos import validate_media_file
 from ricecooker.utils.videos import VideoCompressionError
+from ricecooker.utils.youtube import get_language_with_alpha2_fallback
 from ricecooker.utils.zip import create_predictable_zip
 
 
@@ -529,7 +529,7 @@ class SubtitleConversionHandler(ExtensionMatchingHandler):
         # Language is not present, let's try different codes
         if not converter.has_language(language):
             for lang_code in converter.get_language_codes():
-                language = languages.getlang_by_alpha2(lang_code)
+                language = get_language_with_alpha2_fallback(lang_code)
 
                 if language and language.code == language:
                     convert_lang_code = lang_code

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "requests>=2.11.1",
-        "le_utils>=0.1.26",
+        "le_utils>=0.2.10",
         "requests_file",
         "beautifulsoup4>=4.6.3,<4.9.0",  # pinned to match versions in le-pycaption
         "selenium==4.31.0",

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,12 @@ setup(
         "EbookLib>=0.17.1",
         "filetype>=1.1.0",
         "urllib3==2.4.0",
+        "langcodes[data]==3.5.0",
     ],
     extras_require={
         "test": [
             "requests-cache==1.2.1",
             "pytest==8.3.5",
-            "pycountry==24.6.1",
             "pytest-env==1.1.5",
             "vcrpy==7.0.0; python_version >='3.10'",
             "mock==5.2.0",

--- a/tests/media_utils/test_subtitles.py
+++ b/tests/media_utils/test_subtitles.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from unittest import TestCase
 
+import langcodes
 from le_utils.constants import file_formats
 from le_utils.constants import languages
 
@@ -15,6 +16,13 @@ from ricecooker.utils.subtitles import LANGUAGE_CODE_UNKNOWN
 test_files_dir = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "files", "subtitles"
 )
+
+
+def getlang_by_name(name):
+    language = langcodes.find(name)
+    return languages.getlang(language.to_tag()) or languages.getlang(
+        language.to_alpha3()
+    )
 
 
 class SubtitleConverterTest(TestCase):
@@ -34,7 +42,7 @@ class SubtitleConverterTest(TestCase):
                 self.assertEqual(actual_str.strip(), expected_str.strip())
 
     def test_replace_unknown_language(self):
-        expected_language = languages.getlang_by_name("Arabic")
+        expected_language = getlang_by_name("Arabic")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "basic.srt")
@@ -48,7 +56,7 @@ class SubtitleConverterTest(TestCase):
 
     def test_srt_conversion(self):
         expected_file = os.path.join(test_files_dir, "basic.vtt")
-        expected_language = languages.getlang_by_name("Arabic")
+        expected_language = getlang_by_name("Arabic")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "basic.srt")
@@ -66,7 +74,7 @@ class SubtitleConverterTest(TestCase):
     def test_expected_srt_conversion(self):
         expected_format = file_formats.SRT
         expected_file = os.path.join(test_files_dir, "basic.vtt")
-        expected_language = languages.getlang_by_name("Arabic")
+        expected_language = getlang_by_name("Arabic")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "basic.srt"), in_format=expected_format
@@ -83,7 +91,7 @@ class SubtitleConverterTest(TestCase):
 
     def test_not_expected_type(self):
         expected_format = file_formats.SCC
-        expected_language = languages.getlang_by_name("Arabic")
+        expected_language = getlang_by_name("Arabic")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "basic.srt"), in_format=expected_format
@@ -93,7 +101,7 @@ class SubtitleConverterTest(TestCase):
             converter.convert(expected_language.code)
 
     def test_invalid_format(self):
-        expected_language = languages.getlang_by_name("English")
+        expected_language = getlang_by_name("English")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "not.txt")
@@ -103,7 +111,7 @@ class SubtitleConverterTest(TestCase):
             converter.convert(expected_language.code)
 
     def test_invalid_format__empty(self):
-        expected_language = languages.getlang_by_name("English")
+        expected_language = getlang_by_name("English")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "empty.ttml")
@@ -114,7 +122,7 @@ class SubtitleConverterTest(TestCase):
 
     def test_valid_language(self):
         expected_file = os.path.join(test_files_dir, "encapsulated.vtt")
-        expected_language = languages.getlang_by_name("English")
+        expected_language = getlang_by_name("English")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "encapsulated.sami")
@@ -130,7 +138,7 @@ class SubtitleConverterTest(TestCase):
         os.remove(actual_file_name)
 
     def test_invalid_language(self):
-        expected_language = languages.getlang_by_name("Spanish")
+        expected_language = getlang_by_name("Spanish")
 
         converter = build_subtitle_converter_from_file(
             os.path.join(test_files_dir, "encapsulated.sami")

--- a/tests/media_utils/test_youtube.py
+++ b/tests/media_utils/test_youtube.py
@@ -296,7 +296,9 @@ def test_subtitles_lang_helpers_compatible():
     for youtube_language, sub_dict in vtt_subtitles.items():
         # 2. check compatibility with le-utils language codes (a.k.a. internal representation)
         verdict = youtube.is_youtube_subtitle_file_supported_language(youtube_language)
-        assert verdict, "Wrongly marked youtube_language as incompatible"
+        assert (
+            verdict
+        ), f"Wrongly marked youtube_language {youtube_language} as incompatible"
         # 3. TODO: figure out what to do for incompatible langs
 
         # 4. map youtube_language to le-utils language code (a.k.a. internal representation)

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -140,3 +140,37 @@ def test_is_youtube_subtitle_file_unsupported_language(subtitles_langs_unsupport
         ), "should not be supported"
         lang_obj = get_language_with_alpha2_fallback(lang)
         assert lang_obj is None, "lookup should fail"
+
+
+def test_known_alpha2_codes():
+    lang_obj = get_language_with_alpha2_fallback("en")
+    assert lang_obj is not None, "English not found"
+    assert lang_obj.code == "en", "Wrong code"
+    assert lang_obj.name == "English", "Wrong name"
+    assert lang_obj.native_name == "English", "Wrong native_name"
+
+    lang_obj = get_language_with_alpha2_fallback("zu")
+    assert lang_obj is not None, "Zulu not found"
+    assert lang_obj.code == "zul", "Wrong internal repr. code"
+    assert lang_obj.name == "Zulu", "Wrong name"
+    assert lang_obj.native_name == "isiZulu", "Wrong native_name"
+
+    lang_obj = get_language_with_alpha2_fallback("pt")
+    assert lang_obj is not None, "Portuguese not found"
+    assert lang_obj.code == "pt", "Wrong code"
+    assert lang_obj.name == "Portuguese", "Wrong name"
+    assert lang_obj.native_name == "Português", "Wrong native_name"
+
+
+def test_unknown_alpha2_code():
+    lang_obj = get_language_with_alpha2_fallback("zz")
+    assert lang_obj is None, "Uknown code zz returned non-None"
+
+
+def test_youtube_edgecases_alpha2_codes():
+    # check old language code for Hebrew works `iw`
+    lang_obj = get_language_with_alpha2_fallback("iw")
+    assert lang_obj is not None, "Hebrew not found"
+    assert lang_obj.code == "he", "Wrong code"
+    assert lang_obj.name == "Hebrew (modern)", "Wrong name"
+    assert lang_obj.native_name == "עברית", "Wrong native_name"

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -90,7 +90,7 @@ def subtitles_langs_internal():
 
 @pytest.fixture
 def subtitles_langs_pycountry_mappable():
-    return ["zu"]
+    return ["ab-dab", "zu"]
 
 
 @pytest.fixture
@@ -100,7 +100,7 @@ def subtitles_langs_youtube_custom():
 
 @pytest.fixture
 def subtitles_langs_unsupported():
-    return ["sgn", "zzzza", "ab-dab", "bbb-qqq"]
+    return ["sgn", "zzzza", "bbb-qqq"]
 
 
 @pytest.mark.skipif(True, reason="Requires connecting to youtube.")


### PR DESCRIPTION
## Summary
* Removes use of methods in le-utils for retrieving languages by alpha3 and alpha2 tags
* Use internal methods for this only

## Reviewer guidance
This does clean up so we can remove utilities not used anywhere else in the ecosystem from le-utils.
In general we should defer to the langcodes and pycountry libraries to handle this sort of thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved language code handling for subtitles using enhanced lookup and fallback logic, increasing robustness and compatibility.
- **Bug Fixes**
  - Enhanced error messages in subtitle language compatibility tests for clearer debugging.
- **Chores**
  - Updated dependencies to include the latest language code data and removed unused packages.
- **Tests**
  - Standardized language lookup in tests for consistency.
  - Adjusted test fixtures for more accurate language mapping scenarios.
  - Added new tests to verify language code resolution and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->