### PR TITLE
 Add optional Slack integration for channel upload notifications

### DIFF
--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -12,6 +12,7 @@ from .classes.nodes import ChannelNode
 from .managers.progress import RestoreManager
 from .managers.progress import Status
 from .managers.tree import ChannelManager
+from .utils.slack import send_slack_notification
 
 
 def uploadchannel_wrapper(chef, args, options):
@@ -191,6 +192,9 @@ def uploadchannel(  # noqa: C901
     if prompt and prompt_yes_or_no("Would you like to open your channel now?"):
         config.LOGGER.info("Opening channel... ")
         webbrowser.open_new_tab(channel_link)
+
+    if config.SLACK_WEBHOOK_URL:
+        send_slack_notification(tree.channel, channel_link)
 
     config.PROGRESS_MANAGER.set_done()
     return channel_link

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -269,6 +269,16 @@ try:
 except ImportError:
     pass
 
+# Slack webhook URL for channel upload notifications
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", None)
+if SLACK_WEBHOOK_URL and not SLACK_WEBHOOK_URL.startswith(
+    "https://hooks.slack.com/services/"
+):
+    LOGGER.warning(
+        "Invalid Slack webhook URL provided. Notifications will be disabled."
+    )
+    SLACK_WEBHOOK_URL = None
+
 
 # Record data about past chef runs in chefdata/ dir
 DATA_DIR = "chefdata"

--- a/ricecooker/utils/slack.py
+++ b/ricecooker/utils/slack.py
@@ -1,0 +1,32 @@
+import os
+
+import requests
+
+from ricecooker.config import LOGGER
+
+
+def send_slack_notification(channel, url):
+    """
+    Send a notification to a Slack channel.
+    :param channel: The channel to send the notification to.
+    :param url: The URL of the channel.
+    """
+    if not channel or not url:
+        return
+
+    # Get the webhook URL from the environment variable
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        return
+
+    # Create the message payload
+    payload = {
+        "text": f"A new channel has been uploaded to Kolibri Studio: *{channel.title}* ({channel.get_node_id().hex}). You can view it here: {url}"
+    }
+
+    # Send the request to the webhook URL
+    try:
+        r = requests.post(webhook_url, json=payload)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        LOGGER.error(f"Failed to send Slack notification: {e}")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,34 @@
+import unittest
+
+from mock import patch
+
+from ricecooker.classes.nodes import ChannelNode
+from ricecooker.utils.slack import send_slack_notification
+
+
+class SlackTestCase(unittest.TestCase):
+    @patch("ricecooker.utils.slack.requests.post")
+    def test_send_slack_notification(self, mock_post):
+        """
+        Test that send_slack_notification sends a POST request to the correct URL with the correct payload.
+        """
+        channel = ChannelNode(
+            "fake_source_id",
+            "fake_source_domain",
+            "Test Channel",
+        )
+        url = "https://studio.learningequality.org/en/channels/test-channel-id/"
+
+        with patch.dict(
+            "os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/test"}
+        ):
+            send_slack_notification(channel, url)
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "https://hooks.slack.com/services/test")
+        self.assertIn(
+            "A new channel has been uploaded to Kolibri Studio:", kwargs["json"]["text"]
+        )
+        self.assertIn("Test Channel", kwargs["json"]["text"])
+        self.assertIn(url, kwargs["json"]["text"])


### PR DESCRIPTION
## Summary
- Add a new `send_slack_notification` function to `ricecooker/utils/slack.py` to send a simple text message to a Slack webhook.
- Call the `send_slack_notification` function in `ricecooker/commands.py` after a channel has been successfully uploaded.
