### PR TITLE
Update workflow that handles contributor comments to the latest version + update make lint command to use pre-commit

### DIFF
--- a/.github/workflows/call-contributor-issue-comment.yml
+++ b/.github/workflows/call-contributor-issue-comment.yml
@@ -1,0 +1,12 @@
+name: Handle contributor comment on GitHub issue
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  call-workflow:
+    uses: learningequality/.github/.github/workflows/contributor-issue-comment.yml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL }}

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -1,9 +1,0 @@
-name: Send a slack notification when a contributor comments on issue
-on:
-  issue_comment:
-    types: [created]
-jobs:
-  contributor_issue_comment:
-    uses: learningequality/.github/.github/workflows/notify_team_new_comment.yml@main
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -rf tests/testcontent/downloaded/*
 	rm -rf tests/testcontent/generated/*
 
-lint: ## check style with flake8
-	flake8 ricecooker tests
+lint:
+	pre-commit run --all-files
 
 test: clean-test ## run tests quickly with the default Python
 	pytest


### PR DESCRIPTION
## Summary

- Companion to https://github.com/learningequality/.github/pull/29 which was tested in `test-actions` successfully. Also renames the file to match exactly[ the new example calling script ](https://github.com/learningequality/.github/blob/main/.github/workflows/call-contributor-issue-comment.yml)in `.github` repository.
- Also updates `make lint` to use `pre-commit`