### PR TITLE
Fix downloading a linked css resource with no extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     "pytest-env==1.1.5",
     "vcrpy==7.0.0; python_version >='3.10'",
     "mock==5.2.0",
+    "responses==0.25.8",
 ]
 dev = [
     {include-group = "test"},

--- a/ricecooker/utils/downloader.py
+++ b/ricecooker/utils/downloader.py
@@ -429,7 +429,7 @@ def download_static_assets(  # noqa: C901
         return content
 
     def css_node_filter(node):
-        if "rel" in node:
+        if "rel" in node.attrs:
             return "stylesheet" in node["rel"]
         return node["href"].split("?")[0].strip().endswith(".css")
 

--- a/ricecooker/utils/downloader.py
+++ b/ricecooker/utils/downloader.py
@@ -390,12 +390,12 @@ def download_static_assets(  # noqa: C901
                 # if we're really stuck, just default to HTML as that is most likely if this is a redirect.
                 if not ext:
                     ext = ".html"
-                # may need to add escaping - https://stackoverflow.com/questions/7406102/create-sane-safe-filename-from-any-unsafe-string
-                # this isn't the correct code, dirname grabs the parent directory for a path
-                # safe_path_parts = [os.path.dirname(path_segment) for path_segment in filename.split("/")]
-                safe_path_parts = filename.split("/")
-                subpath = "/".join(safe_path_parts)
-                filename = subpath + "/index{}".format(ext)
+
+                subpath = filename
+                # Add the existing filename in front of index.xxx, this can contain slashes and those will result
+                # in subdirectories created in the downloaded version. This ensures multiple instances of extensionless
+                # resources referenced from a page won't clobber each other.
+                filename = filename + "/index{}".format(ext)
 
                 os.makedirs(os.path.join(destination, subpath), exist_ok=True)
 

--- a/ricecooker/utils/downloader.py
+++ b/ricecooker/utils/downloader.py
@@ -390,8 +390,12 @@ def download_static_assets(  # noqa: C901
                 # if we're really stuck, just default to HTML as that is most likely if this is a redirect.
                 if not ext:
                     ext = ".html"
-                subpath = os.path.dirname(filename)
-                filename = "index{}".format(ext)
+                # may need to add escaping - https://stackoverflow.com/questions/7406102/create-sane-safe-filename-from-any-unsafe-string
+                # this isn't the correct code, dirname grabs the parent directory for a path
+                # safe_path_parts = [os.path.dirname(path_segment) for path_segment in filename.split("/")]
+                safe_path_parts = filename.split("/")
+                subpath = "/".join(safe_path_parts)
+                filename = subpath + "/index{}".format(ext)
 
                 os.makedirs(os.path.join(destination, subpath), exist_ok=True)
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,7 +1,48 @@
+import mimetypes
 import os
+import re
+import tempfile
 import unittest
+from pathlib import Path
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+import responses
 
 from ricecooker.utils import downloader
+
+TESTCONTENT = Path(__file__).resolve().parent / "testcontent"
+
+# Portless host used to serve the checked-in sample tree. A real host (no
+# ":port") keeps the archived paths free of colons, which are illegal in
+# Windows filenames - the reason the previous embedded-server version of this
+# test failed on Windows.
+SAMPLE_HOST = "https://example.org"
+
+
+def _serve_sample_tree(request):
+    """responses callback: serve files from tests/testcontent as a static site.
+
+    Maps the request URL path onto the on-disk sample tree so the fixtures
+    checked in for this test are served verbatim, no local web server needed.
+    """
+    rel_path = unquote(urlparse(request.url).path).lstrip("/")
+    file_path = TESTCONTENT / rel_path
+    if not file_path.is_file():
+        return (404, {}, b"")
+    ext = file_path.suffix
+    if ext == ".html":
+        content_type = "text/html; charset=utf-8"
+    elif ext == "":
+        # Extensionless resources in this fixture are stylesheets; Google Fonts
+        # serves its CSS from an extensionless URL, which is what this test
+        # exercises.
+        content_type = "text/css"
+    else:
+        content_type = (
+            mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+        )
+    return (200, {"Content-Type": content_type}, file_path.read_bytes())
 
 
 class TestArchiver(unittest.TestCase):
@@ -70,3 +111,63 @@ class TestArchiver(unittest.TestCase):
             link_filename, page_filename
         )
         assert rel_path == "../kolibri_1.2.3.png"
+
+
+# The sample tree lives under a subject folder mirroring a real PreTeXt book:
+# activecalculus.org (the page) references a stylesheet from fonts.googleapis.com
+# via an extensionless URL, whose CSS in turn references a font on
+# fonts.gstatic.com.
+SAMPLE_ROOT = "samples/PreTeXt_book_test_manually_cleaned_urls"
+# The Google Fonts stylesheet URL is extensionless; the original had a colon,
+# replaced with an underscore so the fixture file checks out on Windows.
+CSS_URL_PART = "css2_family_Material+Symbols+Outlined_opsz,wght,FILL,GRAD@24,400,0,0"
+
+
+@responses.activate
+def test_pretextbook_css_fetch():
+    """A stylesheet linked via an extensionless URL is archived and rewritten.
+
+    Regression test for two bugs when archiving a PreTeXt book: the CSS
+    ``<link>`` (matched by ``rel="stylesheet"``, not a ``.css`` extension) was
+    skipped, and the generated ``index.css`` for the extensionless resource was
+    dumped at the archive root instead of nested under the resource's own path,
+    which made its relative font references escape the archive directory.
+    """
+    responses.add_callback(
+        responses.GET,
+        re.compile(re.escape(SAMPLE_HOST) + r"/.*"),
+        callback=_serve_sample_tree,
+    )
+
+    page_url = "{}/{}/activecalculus.org/single2e/sec-5-2-FTC2.html".format(
+        SAMPLE_HOST, SAMPLE_ROOT
+    )
+
+    with tempfile.TemporaryDirectory() as download_root:
+        archive = downloader.ArchiveDownloader(download_root)
+        archive.get_page(page_url)
+
+        book_dest_dir = Path(download_root) / "example.org" / SAMPLE_ROOT
+
+        # The page's stylesheet link is rewritten to the nested index.css.
+        page_html = (
+            book_dest_dir / "activecalculus.org" / "single2e" / "sec-5-2-FTC2.html"
+        ).read_text()
+        assert "../../fonts.googleapis.com/" + CSS_URL_PART + "/index.css" in page_html
+
+        # The extensionless stylesheet is nested under its own path as index.css,
+        # not clobbered at the archive root.
+        index_css = book_dest_dir / "fonts.googleapis.com" / CSS_URL_PART / "index.css"
+        css_contents = index_css.read_text()
+        assert "fonts.gstatic.com/s/materialsymbolsoutlined" in css_contents
+
+        # The font referenced from the CSS is downloaded to its own nested path.
+        font_path = (
+            book_dest_dir
+            / "fonts.gstatic.com"
+            / "s"
+            / "materialsymbolsoutlined"
+            / "v290"
+            / "material_symbols.woff"
+        )
+        assert font_path.stat().st_size > 0

--- a/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/activecalculus.org/single2e/sec-5-2-FTC2.html
+++ b/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/activecalculus.org/single2e/sec-5-2-FTC2.html
@@ -1,0 +1,22 @@
+<html dir="ltr" lang="en-US">
+ <!--******************************************-->
+ <!--*  Authored with PreTeXt                 *-->
+ <!--*  pretextbook.org                       *-->
+ <!--*  Theme: default-modern                 *-->
+ <!--*  Palette: blues                        *-->
+ <!--******************************************-->
+ <head xmlns:book="https://ogp.me/ns/book#" xmlns:og="http://ogp.me/ns#">
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <title>
+   AC The Second Fundamental Theorem of Calculus
+  </title>
+  <link href="" rel="preconnect"/>
+  <link crossorigin="sec-5-2-FTC2.html" href="" rel="preconnect"/>
+  <link href="../../fonts.googleapis.com/css2_family_Material+Symbols+Outlined_opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet"/>
+ </head>
+ <body class="pretext book ignore-math">
+  <span aria-hidden="true" class="icon material-symbols-outlined">
+   
+  </span>
+ </body>
+</html>

--- a/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/fonts.googleapis.com/css2_family_Material+Symbols+Outlined_opsz,wght,FILL,GRAD@24,400,0,0
+++ b/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/fonts.googleapis.com/css2_family_Material+Symbols+Outlined_opsz,wght,FILL,GRAD@24,400,0,0
@@ -1,0 +1,21 @@
+@font-face {
+  font-family: 'Material Symbols Outlined';
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts.gstatic.com/s/materialsymbolsoutlined/v290/material_symbols.woff") format('woff');
+}
+
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -moz-font-feature-settings: 'liga';
+}

--- a/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/fonts.gstatic.com/s/materialsymbolsoutlined/v290/material_symbols.woff
+++ b/tests/testcontent/samples/PreTeXt_book_test_manually_cleaned_urls/fonts.gstatic.com/s/materialsymbolsoutlined/v290/material_symbols.woff
@@ -1,0 +1,1 @@
+Not really a font, just a placeholder file.

--- a/uv.lock
+++ b/uv.lock
@@ -1460,6 +1460,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.25.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "platform_python_implementation == 'CPython'" },
+    { name = "requests", marker = "platform_python_implementation == 'CPython'" },
+    { name = "urllib3", marker = "platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/95/89c054ad70bfef6da605338b009b2e283485835351a9935c7bfbfaca7ffc/responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4", size = 79320, upload-time = "2025-08-08T19:01:46.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c", size = 34769, upload-time = "2025-08-08T19:01:45.018Z" },
+]
+
+[[package]]
 name = "ricecooker"
 source = { editable = "." }
 dependencies = [
@@ -1503,6 +1517,7 @@ dev = [
     { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
     { name = "pytest-env", marker = "platform_python_implementation == 'CPython'" },
     { name = "requests-cache", marker = "platform_python_implementation == 'CPython'" },
+    { name = "responses", marker = "platform_python_implementation == 'CPython'" },
     { name = "ruff", marker = "platform_python_implementation == 'CPython'" },
     { name = "vcrpy", marker = "python_full_version >= '3.10' and platform_python_implementation == 'CPython'" },
 ]
@@ -1511,6 +1526,7 @@ test = [
     { name = "pytest", marker = "platform_python_implementation == 'CPython'" },
     { name = "pytest-env", marker = "platform_python_implementation == 'CPython'" },
     { name = "requests-cache", marker = "platform_python_implementation == 'CPython'" },
+    { name = "responses", marker = "platform_python_implementation == 'CPython'" },
     { name = "vcrpy", marker = "python_full_version >= '3.10' and platform_python_implementation == 'CPython'" },
 ]
 
@@ -1550,6 +1566,7 @@ dev = [
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-env", specifier = "==1.1.5" },
     { name = "requests-cache", specifier = "==1.2.1" },
+    { name = "responses", specifier = "==0.25.8" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "vcrpy", marker = "python_full_version >= '3.10'", specifier = "==7.0.0" },
 ]
@@ -1558,6 +1575,7 @@ test = [
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-env", specifier = "==1.1.5" },
     { name = "requests-cache", specifier = "==1.2.1" },
+    { name = "responses", specifier = "==0.25.8" },
     { name = "vcrpy", marker = "python_full_version >= '3.10'", specifier = "==7.0.0" },
 ]
 


### PR DESCRIPTION
<!--
 2. After saving the PR, tick of completed checklist items
-->

## Summary
While trying to download a textbook written with PreteXt, I ran into an issue with some google icons that they use not rendering properly. I found two bugs, one was incorrect filtering of css resources in link tags. The second bug involved the ArchiveDownloader incorrectly placing a generated filename of index.css at the root of the download, when hitting a linked resource with no extension, instead of nesting it into sub-directories relevant for the domain and other url paths of the resource. This caused further resources requested below the CSS file to incorrectly reference outside of the download directory entirely.

<img width="479" height="434" alt="Screenshot from 2025-10-23 12-42-19" src="https://github.com/user-attachments/assets/20341117-6871-4e21-bafa-b74d339e1e5e" />

<img width="479" height="434" alt="Screenshot from 2025-10-22 13-47-58" src="https://github.com/user-attachments/assets/282f3160-5254-4090-8948-9c1c61f0243c" />

I saw this in the run of the ArchiveDownloader, which meant that this URL was not being downloaded/rewritten:
```Skipping node with src  https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0```

This is the relevant line from the source site:
``` <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0">```

I found a bug in css_node_filter, it was excluding this tag even though it had a "rel" attribute. While the attributes can be accessed from the root Tag object like `node["rel"]`, the `in` operator doesn't work as they are in a sub-property that gets re-exposed by the class.

Observed results of download with this first change to fix the css resource filtering
```
downloads/active_calc_2e_again_823433/
├── activecalculus.org
│   └── single2e
│       ├── external
│       ├── frontmatter.html
├── fonts.googleapis.com
├── fonts.gstatic.com
│   └── s
│       └── materialsymbolsoutlined
│           └── v290
│               └── kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOel.woff
├── index.css
```

The index.css file that was placed at the root had these contents, meaning it was making a relative path reference outside of the download directory:
```
@font-face {
  font-family: 'Material Symbols Outlined';
  font-style: normal;
  font-weight: 400;
  src: url("../../fonts.gstatic.com/s/materialsymbolsoutlined/v290/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOel.woff") format('woff');
}
```

It seemed like the correct fix was to get this index.css to be placed down into the file-system hierarchy based on the resource URL, rather than change how this relative path was being generated. The fix was simple once I found the relevant line of code to change. Currently the diff is a little bigger than needed as I assumed I might want to do some escaping of the URL to turn it into a file path, but thinking a bit longer on it I thought it might be reasonably likely anything that can be in an HTTP URL might be fine to be in a unix path (assuming this tool is only going to be run in unix environments), and that all slashes are used to create sub-directories. I can simplify it down the the one line version of the fix and remove the todo if you agree.

## References
Page I was downloading:
https://activecalculus.org/single2e/frontmatter.html

## Reviewer guidance
I'm interested in adding a automated test, I don't necessarily want to hot link to the source site in a test, but as this is just for the scraping library I assume these tests aren't run that often. Considering if it might be useful to add some kind of test tool that would enable just checking in a directory of test web resources that could be "downloaded" by exposing them through a little local webserver or something. Happy to hear any thoughts or guidance on testing.