### PR TITLE
Add AGENTS.md and CLAUDE.md for AI agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Quick Start
+
+```bash
+pip install -e '.[test,dev]'        # install (use uv pip if venv was created with uv)
+pytest                              # run all tests
+pytest tests/test_files.py          # run a single test file
+pytest -k 'test_something'         # filter by test name
+pre-commit run --all-files          # lint (the ONLY way to run linting)
+```
+
+**System dependencies:** `ffmpeg` and `poppler-utils`.
+
+## Critical Gotchas
+
+- **Linting:** Always use `pre-commit run --all-files`. Never run black, flake8, or other tools directly.
+- **Line length:** 160 characters, enforced by pre-commit.
+- **New file types require exactly two changes:** (1) a conversion handler in `convert.py`, (2) a metadata extractor in `extract_metadata.py`. That's it. Do NOT touch `classes/files.py` or `classes/nodes.py` — the existing File/Node subclasses there are legacy backwards-compatibility APIs that are NOT needed for new file types. The pipeline infers kinds and presets automatically.
+- **Test placement:** Pipeline tests go in `tests/pipeline/` — add to existing files like `test_convert.py` and `test_extract_metadata.py`. Do not create new test files.
+- **Validation logic:** Each handler implements only the validation its spec requires. Do not copy validation from other handlers (e.g., do not add HTML body parsing or empty-body checks unless the spec explicitly requires them).
+- **le_utils constants:** Always verify constants exist by running `python3 -c "from le_utils.constants import file_formats, format_presets; print(file_formats.CONSTANT_NAME); print(format_presets.CONSTANT_NAME)"`. Names are often non-obvious (e.g., `file_formats.HTML5_ARTICLE` for kpub, `format_presets.KPUB_ZIP` not `format_presets.KPUB`).
+
+## Project Overview
+
+Ricecooker converts educational content into Kolibri content channels and uploads to Kolibri Studio. Chef scripts subclass `SushiChef`, build a node/file tree, and call `main()`.
+
+## Key Architecture
+
+- **`utils/pipeline/`**: File processing pipeline — transfer → convert → extract_metadata. Reference architecture for new code.
+- **`classes/nodes.py`**: Node tree (`ChannelNode`, `TopicNode`, `ContentNode` subclasses) — legacy, do not add new subclasses
+- **`classes/files.py`**: File classes (`DownloadFile` subclasses) — legacy, do not add new subclasses
+- **`chefs.py`**: `SushiChef` base class
+- **`le_utils`**: External package providing content model constants (`file_formats`, `format_presets`, `content_kinds`, `licenses`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,37 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What is Ricecooker
+@AGENTS.md
 
-A Python framework for converting educational content into Kolibri content channels and uploading them to Kolibri Studio. Content integration scripts ("chefs") subclass `SushiChef`, build a tree of nodes and files, and call `main()` to process and upload everything.
-
-## Commands
-
-```bash
-pip install -e '.[test,dev]'        # install for development (use uv pip if venv was created with uv)
-pytest                              # run all tests
-pytest tests/test_files.py          # run a single test file
-pytest -k 'test_something'         # filter by test name
-pre-commit run --all-files          # lint (the only way to run linting)
-```
-
-**System dependencies required:** `ffmpeg` and `poppler-utils`.
-
-**Code style:** max line length is 160 characters, enforced by black via pre-commit.
-
-## Architecture
+## Extended Architecture
 
 ### End-to-End Flow
 
 Chef script builds node tree → `uploadchannel()` validates → processes all files (download, convert, extract metadata) → diffs against Studio → uploads missing files → uploads channel structure → optionally publishes.
-
-### Key Modules
-
-- **`chefs.py`**: `SushiChef` base class (override `construct_channel()`), plus `JsonTreeChef`, `LineCook`, `YouTubeSushiChef`
-- **`classes/nodes.py`**: `ChannelNode` (root), `TopicNode` (folders), `ContentNode` subclasses (`VideoNode`, `AudioNode`, `DocumentNode`, `HTML5AppNode`, `ExerciseNode`, `SlideshowNode`)
-- **`classes/files.py`**: `DownloadFile` subclasses (`VideoFile`, `AudioFile`, `DocumentFile`, `HTMLZipFile`, `H5PFile`, etc.)
-- **`managers/tree.py`**: `ChannelManager` — orchestrates validation, processing, upload
-- **`utils/pipeline/`**: File processing pipeline (see below)
 
 ### File Processing Pipeline (`utils/pipeline/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Ricecooker
+
+A Python framework for converting educational content into Kolibri content channels and uploading them to Kolibri Studio. Content integration scripts ("chefs") subclass `SushiChef`, build a tree of nodes and files, and call `main()` to process and upload everything.
+
+## Commands
+
+```bash
+pip install -e '.[test,dev]'        # install for development (use uv pip if venv was created with uv)
+pytest                              # run all tests
+pytest tests/test_files.py          # run a single test file
+pytest -k 'test_something'         # filter by test name
+pre-commit run --all-files          # lint (the only way to run linting)
+```
+
+**System dependencies required:** `ffmpeg` and `poppler-utils`.
+
+**Code style:** max line length is 160 characters, enforced by black via pre-commit.
+
+## Architecture
+
+### End-to-End Flow
+
+Chef script builds node tree → `uploadchannel()` validates → processes all files (download, convert, extract metadata) → diffs against Studio → uploads missing files → uploads channel structure → optionally publishes.
+
+### Key Modules
+
+- **`chefs.py`**: `SushiChef` base class (override `construct_channel()`), plus `JsonTreeChef`, `LineCook`, `YouTubeSushiChef`
+- **`classes/nodes.py`**: `ChannelNode` (root), `TopicNode` (folders), `ContentNode` subclasses (`VideoNode`, `AudioNode`, `DocumentNode`, `HTML5AppNode`, `ExerciseNode`, `SlideshowNode`)
+- **`classes/files.py`**: `DownloadFile` subclasses (`VideoFile`, `AudioFile`, `DocumentFile`, `HTMLZipFile`, `H5PFile`, etc.)
+- **`managers/tree.py`**: `ChannelManager` — orchestrates validation, processing, upload
+- **`utils/pipeline/`**: File processing pipeline (see below)
+
+### File Processing Pipeline (`utils/pipeline/`)
+
+The pipeline is the best-architected part of the codebase. **Use it as the reference model for new code.**
+
+Three stages with ordered handlers: **transfer** (download) → **convert** (compress/transform) → **extract_metadata**. Handlers implement `should_handle()` / `execute()`. Transfer uses `FirstHandlerOnly` mode; convert and metadata use `AllHandlers` mode.
+
+### le_utils Dependency
+
+`le_utils` provides constants defining the Kolibri content model: `content_kinds`, `file_formats`, `format_presets`, `licenses`, `languages`, and label taxonomies. It increasingly includes validation schemas that ricecooker should conform to.
+
+## Development Notes
+
+- The pipeline code is the reference architecture — follow its OOP patterns when writing new code.
+- Older code (especially `ricecooker/classes/`) has less test coverage. Take extra care when modifying it.
+- PRs target `main` on `learningequality/ricecooker`. CI tests Python 3.9–3.13 on Linux, macOS, and Windows.
+
+### Adding support for new file types
+
+Adding a new file type requires exactly two changes to the pipeline:
+1. A conversion handler in `convert.py` (subclass `ArchiveProcessingBaseHandler` for zip-based formats) — registered in `ConversionStageHandler.DEFAULT_CHILDREN`
+2. A metadata extractor in `extract_metadata.py` (subclass `MetadataExtractor`, add extension-to-preset mapping in `PRESETS_FROM_EXTENSIONS`) — registered in `ExtractMetadataStageHandler.DEFAULT_CHILDREN`
+
+The pipeline automatically infers content kind and preset from file extensions. Since the pipeline refactor, most dedicated `File` subclasses (e.g., `HTMLZipFile`, `DocumentFile`) and `Node` subclasses (e.g., `HTML5AppNode`, `DocumentNode`) are essentially backwards-compatibility APIs — in most cases the same effect is achieved by using `ContentNode` with a `uri` parameter. Do **not** create new `File` or `Node` subclasses, or modify existing ones to add presets, when adding new file type support. Only modify `classes/` modules if explicitly asked or if runtime context beyond what the pipeline provides is needed (e.g., subtitles, exercise questions).
+
+Each handler should implement only the validation logic specified in its requirements. Do not copy validation logic from other handlers (e.g., HTML body parsing) unless the requirements call for it.
+
+### Test organization
+
+Pipeline tests go in `tests/pipeline/` (e.g. `test_convert.py`, `test_extract_metadata.py`). Add new tests to existing files in the appropriate directory rather than creating new top-level test files.


### PR DESCRIPTION
## Summary

Add two documentation files to guide AI coding agents working in this repository:

- **`AGENTS.md`** — Concise, model-agnostic guidance (36 lines) with commands-first layout, critical gotchas, project overview, and key architecture. Designed to fit in smaller context windows.
- **`CLAUDE.md`** — Imports `AGENTS.md` via `@AGENTS.md` reference and adds Claude Code-specific extensions: detailed pipeline architecture, `le_utils` dependency context, and expanded file type implementation guidance.

The `AGENTS.md` content was validated through 3 rounds of TDD testing (RED-GREEN-REFACTOR) using Haiku and Sonnet subagents with a KPUB file type implementation task. Each round identified common agent mistakes and refined the gotchas to prevent them. Key gotchas that proved effective:

- Preventing agents from creating new File/Node subclasses in legacy `classes/` modules
- Requiring `le_utils` constant verification before use (names are non-obvious)
- Enforcing correct test placement in `tests/pipeline/`
- Preventing over-copying of validation logic from existing handlers

## References

Follows the AGENTS.md / CLAUDE.md split pattern from [Kolibri PR #14164](https://github.com/learningequality/kolibri/pull/14164).

## Reviewer guidance

- These are documentation-only changes (no code modifications)
- **AGENTS.md Critical Gotchas section** — Does this accurately capture the most common agent mistakes when working in this codebase? Are there other gotchas that should be added?
- **CLAUDE.md extended architecture** — Does this provide enough context for Claude Code without being redundant with AGENTS.md?
- The TDD validation found that HTML body parsing over-copying and File subclass creation (for Haiku) remain hard to prevent through documentation alone — these may need structural guardrails in the future