### PR TITLE
Fix #659: question.validate() return False instead of raising AssertionError

### DIFF
--- a/ricecooker/classes/questions.py
+++ b/ricecooker/classes/questions.py
@@ -8,7 +8,6 @@ from bs4 import BeautifulSoup
 from le_utils.constants import exercises
 
 from .. import config
-from ..exceptions import InvalidQuestionException
 from .files import _ExerciseBase64ImageFile
 from .files import _ExerciseGraphieFile
 from .files import _ExerciseImageFile
@@ -219,25 +218,22 @@ class BaseQuestion:
         Args: None
         Returns: boolean indicating if question is valid
         """
-        assert self.id is not None, "Assumption Failed: Question must have an id"
-        assert (
-            isinstance(self.question, str) or self.question is None
-        ), "Assumption Failed: Question must be a string"
-        assert isinstance(
-            self.question_type, str
-        ), "Assumption Failed: Question type must be a string"
-        assert isinstance(
-            self.answers, list
-        ), "Assumption Failed: Answers must be a list"
-        assert isinstance(self.hints, list), "Assumption Failed: Hints must be a list"
+        if self.id is None:
+            return False
+        if not (isinstance(self.question, str) or self.question is None):
+            return False
+        if not isinstance(self.question_type, str):
+            return False
+        if not isinstance(self.answers, list):
+            return False
+        if not isinstance(self.hints, list):
+            return False
         for a in self.answers:
-            assert isinstance(
-                a, dict
-            ), "Assumption Failed: Answer in answer list is not a dict"
+            if not isinstance(a, dict):
+                return False
         for h in self.hints:
-            assert isinstance(
-                h, str
-            ), "Assumption Failed: Hint in hints list is not a string"
+            if not isinstance(h, str):
+                return False
         return True
 
 
@@ -274,24 +270,15 @@ class PerseusQuestion(BaseQuestion):
         Args: None
         Returns: boolean indicating if perseus question is valid
         """
-        try:
-            assert (
-                self.question == ""
-            ), "Assumption Failed: Perseus question should not have a question"
-            assert (
-                self.question_type == exercises.PERSEUS_QUESTION
-            ), "Assumption Failed: Question should be perseus type"
-            assert (
-                self.answers == []
-            ), "Assumption Failed: Answer list should be empty for perseus question"
-            assert (
-                self.hints == []
-            ), "Assumption Failed: Hints list should be empty for perseus question"
-            return super(PerseusQuestion, self).validate()
-        except AssertionError:
-            raise InvalidQuestionException(
-                "Invalid question: {0}".format(self.__dict__)
-            )
+        if self.question != "":
+            return False
+        if self.question_type != exercises.PERSEUS_QUESTION:
+            return False
+        if self.answers != []:
+            return False
+        if self.hints != []:
+            return False
+        return super(PerseusQuestion, self).validate()
 
     def _replace_image(self, match):
         protocol = match.group("protocol")
@@ -390,29 +377,19 @@ class MultipleSelectQuestion(BaseQuestion):
         Args: None
         Returns: boolean indicating if multiple selection question is valid
         """
-        try:
-            assert (
-                self.question_type == exercises.MULTIPLE_SELECTION
-            ), "Assumption Failed: Question should be multiple selection type"
-            assert (
-                len(self.answers) > 0
-            ), "Assumption Failed: Multiple selection question should have answers"
-            for a in self.answers:
-                assert "answer" in a and isinstance(
-                    a["answer"], str
-                ), "Assumption Failed: Answer in answer list is not a string"
-                assert "correct" in a and isinstance(
-                    a["correct"], bool
-                ), "Assumption Failed: Correct indicator is not a boolean in answer list"
-            for h in self.hints:
-                assert isinstance(
-                    h, str
-                ), "Assumption Failed: Hint in hint list is not a string"
-            return super(MultipleSelectQuestion, self).validate()
-        except AssertionError:
-            raise InvalidQuestionException(
-                "Invalid question: {0}".format(self.__dict__)
-            )
+        if self.question_type != exercises.MULTIPLE_SELECTION:
+            return False
+        if len(self.answers) <= 0:
+            return False
+        for a in self.answers:
+            if "answer" not in a or not isinstance(a["answer"], str):
+                return False
+            if "correct" not in a or not isinstance(a["correct"], bool):
+                return False
+        for h in self.hints:
+            if not isinstance(h, str):
+                return False
+        return super(MultipleSelectQuestion, self).validate()
 
 
 class SingleSelectQuestion(BaseQuestion):
@@ -454,34 +431,23 @@ class SingleSelectQuestion(BaseQuestion):
         Args: None
         Returns: boolean indicating if single selection question is valid
         """
-        try:
-            assert (
-                self.question_type == exercises.SINGLE_SELECTION
-            ), "Assumption Failed: Question should be single selection type"
-            assert (
-                len(self.answers) > 0
-            ), "Assumption Failed: Multiple selection question should have answers"
-            correct_answers = 0
-            for a in self.answers:
-                assert "answer" in a and isinstance(
-                    a["answer"], str
-                ), "Assumption Failed: Answer in answer list is not a string"
-                assert "correct" in a and isinstance(
-                    a["correct"], bool
-                ), "Assumption Failed: Correct indicator is not a boolean in answer list"
-                correct_answers += 1 if a["correct"] else 0
-            assert (
-                correct_answers == 1
-            ), "Assumption Failed: Single selection question should have only one correct answer"
-            for h in self.hints:
-                assert isinstance(
-                    h, str
-                ), "Assumption Failed: Hint in hints list is not a string"
-            return super(SingleSelectQuestion, self).validate()
-        except AssertionError:
-            raise InvalidQuestionException(
-                "Invalid question: {0}".format(self.__dict__)
-            )
+        if self.question_type != exercises.SINGLE_SELECTION:
+            return False
+        if len(self.answers) <= 0:
+            return False
+        correct_answers = 0
+        for a in self.answers:
+            if "answer" not in a or not isinstance(a["answer"], str):
+                return False
+            if "correct" not in a or not isinstance(a["correct"], bool):
+                return False
+            correct_answers += 1 if a["correct"] else 0
+        if correct_answers != 1:
+            return False
+        for h in self.hints:
+            if not isinstance(h, str):
+                return False
+        return super(SingleSelectQuestion, self).validate()
 
 
 class InputQuestion(BaseQuestion):
@@ -516,29 +482,18 @@ class InputQuestion(BaseQuestion):
         Args: None
         Returns: boolean indicating if input question is valid
         """
-        try:
-            assert (
-                self.question_type == exercises.INPUT_QUESTION
-            ), "Assumption Failed: Question should be input answer type"
-            assert (
-                len(self.answers) > 0
-            ), "Assumption Failed: Multiple selection question should have answers"
-            for a in self.answers:
-                assert (
-                    "answer" in a
-                ), "Assumption Failed: Answers must have an answer field"
-                try:
-                    float(a["answer"])
-                except ValueError:
-                    assert False, "Assumption Failed: Answer {} must be numeric".format(
-                        a["answer"]
-                    )
-            for h in self.hints:
-                assert isinstance(
-                    h, str
-                ), "Assumption Failed: Hint in hints list is not a string"
-            return super(InputQuestion, self).validate()
-        except AssertionError:
-            raise InvalidQuestionException(
-                "Invalid question: {0}".format(self.__dict__)
-            )
+        if self.question_type != exercises.INPUT_QUESTION:
+            return False
+        if len(self.answers) <= 0:
+            return False
+        for a in self.answers:
+            if "answer" not in a:
+                return False
+            try:
+                float(a["answer"])
+            except (ValueError, TypeError):
+                return False
+        for h in self.hints:
+            if not isinstance(h, str):
+                return False
+        return super(InputQuestion, self).validate()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,7 +8,6 @@ from le_utils.constants import content_kinds
 from ricecooker.classes.nodes import ChannelNode
 from ricecooker.classes.nodes import TopicNode
 from ricecooker.exceptions import InvalidNodeException
-from ricecooker.exceptions import InvalidQuestionException
 
 
 """ *********** CHANNEL TESTS *********** """
@@ -68,7 +67,7 @@ def test_validate(
     pytest.raises(InvalidNodeException, html_invalid_files.process_files)
     pytest.raises(InvalidNodeException, html_invalid_zip.process_files)
     assert exercise.validate(), "Valid html content should pass validation"
-    pytest.raises(InvalidQuestionException, exercise_invalid_question.validate)
+    pytest.raises(InvalidNodeException, exercise_invalid_question.validate)
 
 
 """ *********** ALT DOMAIN TESTS *********** """

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -170,6 +170,32 @@ def test_exercise_extra_fields_float(exercise):
     exercise.validate()
 
 
+def test_exercise_invalid_question_raises_invalid_node_exception(exercise_data):
+    """Invalid questions (e.g. SingleSelect with zero correct answers) produce
+    InvalidNodeException via _validate_values, not raw AssertionError (issue #659).
+    """
+    # SingleSelectQuestion with no correct answer (all correct=False)
+    bad_question = SingleSelectQuestion(
+        id="bad",
+        question="Q?",
+        correct_answer="A",
+        all_answers=["A", "B", "C"],
+    )
+    for a in bad_question.answers:
+        a["correct"] = False
+
+    node = ExerciseNode(
+        source_id=exercise_data["id"],
+        title=exercise_data["title"],
+        author=exercise_data["author"],
+        license=exercise_data["license"],
+        questions=[bad_question],
+    )
+    with pytest.raises(InvalidNodeException) as exc_info:
+        node.validate()
+    assert "invalid question" in str(exc_info.value).lower()
+
+
 ################################################################################
 # Perseus image asset processing and image loading tests
 ################################################################################


### PR DESCRIPTION
Fixes #659

## Problem
`BaseQuestion.validate()` and its subclasses (`PerseusQuestion`, `MultipleSelectQuestion`, `SingleSelectQuestion`, `InputQuestion`) used `assert` statements. When a question was invalid, they raised `AssertionError` (or `InvalidQuestionException` in subclasses) before the node’s `_validate_values()` could run. That led to raw stack traces instead of the usual `InvalidNodeException` with a clear message.

## Solution
- **Question classes:** All `validate()` methods now return `True` or `False` instead of using `assert` or raising. Invalid cases are handled with explicit checks that return `False`.
- **Node validation:** `ExerciseNode._validate()` already calls `_validate_values(any(not q.validate() for q in self.questions), "Exercise has invalid question")`. With `validate()` returning a boolean, this now runs as intended and raises `InvalidNodeException` with the message "Exercise has invalid question".
- **Tests:** `test_validate` was updated to expect `InvalidNodeException` for an exercise with an invalid question. A new test `test_exercise_invalid_question_raises_invalid_node_exception` was added to cover a `SingleSelectQuestion` with zero correct answers.

## Acceptance criteria (from #659)
- [x] `question.validate()` methods return `False` for invalid questions instead of raising `AssertionError`
- [x] Node `_validate()` methods collect question validation errors through `_validate_values()` like other validation checks
- [x] Invalid questions produce `InvalidNodeException` with descriptive messages
- [x] Existing tests continue to pass (one expectation updated, one new test added)