### PR TITLE
Fix preset lookup for base64 exercise images

### DIFF
--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -393,6 +393,13 @@ class Base64ImageFile(ThumbnailPresetMixin, DownloadFile):
 class _ExerciseBase64ImageFile(Base64ImageFile):
     default_preset = format_presets.EXERCISE_IMAGE
 
+    def get_preset(self):
+        # Exercise images are attached to a question, not a node, so the
+        # ThumbnailPresetMixin.get_preset inherited from Base64ImageFile
+        # (which dereferences self.node) does not apply. Use the exercise
+        # image preset, mirroring _ExerciseImageFile.
+        return self.preset or self.default_preset
+
     def get_replacement_str(self):
         return self.get_filename() or self.path
 

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -8,6 +8,7 @@ import uuid
 
 import pytest
 from le_utils.constants import exercises
+from le_utils.constants import format_presets
 from le_utils.constants import licenses
 from test_videos import _clear_ricecookerfilecache
 
@@ -393,6 +394,14 @@ def test_exercise_base64_image_file(
     filename = exercise_base64_image_file.get_filename()
     assert filename == exercise_base64_image_filename, (
         "wrong filename for _ExerciseBase64ImageFile"
+    )
+
+
+def test_exercise_base64_image_preset(exercise_base64_image_file):
+    # Exercise images are attached to a question, not a node, so get_preset
+    # must not rely on ThumbnailPresetMixin's node dereference.
+    assert exercise_base64_image_file.get_preset() == format_presets.EXERCISE_IMAGE, (
+        "wrong preset for _ExerciseBase64ImageFile"
     )
 
 


### PR DESCRIPTION
## Summary

`_ExerciseBase64ImageFile` inherits `ThumbnailPresetMixin.get_preset` via `Base64ImageFile`, which dereferences `self.node` — but exercise images are attached to a question, not a node, so calling `get_preset()` raised `AttributeError`. Override it to return the exercise image preset, mirroring the sibling `_ExerciseImageFile`.

## References

Extracted from in-progress spreadsheet chef work; no linked issue.

## Reviewer guidance

`uv run --group test pytest tests/test_exercises.py` — the new test was verified to fail with `AttributeError` before the fix.

## AI usage

I used Claude Code to extract this fix from a larger working branch and add the regression test; I reviewed the final diff.