### PR TITLE
Pass compression settings through the pipeline default context

### DIFF
--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -494,7 +494,16 @@ class SushiChef(object):
         self.CHEF_RUN_DATA["current_run"] = run_id
         self.CHEF_RUN_DATA["runs"].append({"id": run_id})
 
-        self.file_pipeline = FilePipeline()
+        default_context = {}
+        if self.get_setting("compress", False):
+            default_context["video_settings"] = {
+                "crf": 32,
+                "max_height": self.get_setting("video-height") or 720,
+            }
+            default_context["audio_settings"] = {
+                "bit_rate": 96,
+            }
+        self.file_pipeline = FilePipeline(default_context=default_context)
         self.auth = DomainSpecificAuth(self.DOMAIN_AUTH_HEADERS)
         # TODO(Kevin): move self.download_content() call here
         self.pre_run(args, options)

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -62,7 +62,6 @@ def uploadchannel(  # noqa: C901
 
     # Set configuration settings
     config.UPDATE = update
-    config.COMPRESS = chef.get_setting("compress", False)
     config.VIDEO_HEIGHT = chef.get_setting("video-height", None)
     config.THUMBNAILS = chef.get_setting("thumbnails", False)
     config.STAGE = stage

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -15,7 +15,6 @@ from requests_file import FileAdapter
 
 
 UPDATE = False
-COMPRESS = False
 VIDEO_HEIGHT = None
 THUMBNAILS = False
 PUBLISH = False

--- a/ricecooker/utils/pipeline/__init__.py
+++ b/ricecooker/utils/pipeline/__init__.py
@@ -52,6 +52,10 @@ class FilePipeline(CompositeHandler):
         ExtractMetadataStageHandler,
     ]
 
+    def __init__(self, children=None, default_context=None):
+        super().__init__(children=children)
+        self.default_context = default_context or {}
+
     def execute(
         self,
         path: str,
@@ -61,7 +65,10 @@ class FilePipeline(CompositeHandler):
         """
         Execute the pipeline for a given file path.
         """
-        context = context or {}
+        merged_context = self.default_context.copy()
+        if context:
+            merged_context.update(context)
+        context = merged_context
         file_metadata_list = [FileMetadata(path=path)]
         for handler in self._children:
             updated_file_metadata_list = []

--- a/ricecooker/utils/pipeline/convert.py
+++ b/ricecooker/utils/pipeline/convert.py
@@ -30,7 +30,6 @@ from PyPDF2.utils import PdfReadError
 
 from .file_handler import ExtensionMatchingHandler
 from .file_handler import StageHandler
-from ricecooker import config
 from ricecooker.exceptions import UnknownFileTypeError
 from ricecooker.utils.audio import AudioCompressionError
 from ricecooker.utils.audio import compress_audio
@@ -98,8 +97,8 @@ class VideoCompressionHandler(MediaCompressionHandler):
 
         if input_ext in self.SUPPORTED_VIDEO_EXTS:
             output_ext = input_ext
-            if not config.COMPRESS and not ffmpeg_settings:
-                # If we're not compressing, just validate the file.
+            if not ffmpeg_settings:
+                # No compression settings provided, just validate the file.
                 is_valid, error = validate_media_file(path)
                 if not is_valid:
                     raise InvalidFileException(
@@ -144,8 +143,8 @@ class AudioCompressionHandler(MediaCompressionHandler):
         ext = extract_path_ext(path)
 
         if ext in self.SUPPORTED_AUDIO_EXTS:
-            if not config.COMPRESS and not ffmpeg_settings:
-                # If we're not compressing, just validate the file.
+            if not ffmpeg_settings:
+                # No compression settings provided, just validate the file.
                 is_valid, error = validate_media_file(path)
                 if not is_valid:
                     raise InvalidFileException(
@@ -168,7 +167,7 @@ class ArchiveProcessingBaseHandler(ExtensionMatchingHandler):
     CONTEXT_CLASS = ArchiveProcessingContextMetadata
 
     def get_cache_key(self, path, audio_settings=None, video_settings=None) -> str:
-        if not config.COMPRESS:
+        if not audio_settings and not video_settings:
             return super().get_cache_key(path)
         # Mirror the old compress_files_in_archive logic, which used:
         # generate_key("COMPRESSED", filename, settings=ffmpeg_settings)
@@ -198,17 +197,18 @@ class ArchiveProcessingBaseHandler(ExtensionMatchingHandler):
 
         ext = extract_path_ext(path)
 
-        # Create partial for reading & compressing subfiles
-        file_converter = partial(
-            self._read_and_compress_archive_file,
-            audio_settings=audio_settings,
-            video_settings=video_settings,
-            ext=ext,
-        )
+        # Compress subfiles only when explicit settings are provided,
+        # mirroring the standalone media compression handlers.
+        file_converter = None
+        if audio_settings or video_settings:
+            file_converter = partial(
+                self._read_and_compress_archive_file,
+                audio_settings=audio_settings,
+                video_settings=video_settings,
+                ext=ext,
+            )
         # create_predictable_zip will iterate over subfiles, call file_converter
-        processed_zip_path = create_predictable_zip(
-            path, file_converter=file_converter if config.COMPRESS else None
-        )
+        processed_zip_path = create_predictable_zip(path, file_converter=file_converter)
 
         with self.write_file(ext) as fh:
             with open(processed_zip_path, "rb") as zf:

--- a/tests/pipeline/test_convert.py
+++ b/tests/pipeline/test_convert.py
@@ -7,15 +7,16 @@ from unittest.mock import patch
 
 import pytest
 
-from ricecooker.classes.files import H5PFile
-from ricecooker.classes.files import HTMLZipFile
+from ricecooker.utils.pipeline.convert import AudioCompressionHandler
+from ricecooker.utils.pipeline.convert import H5PConversionHandler
 from ricecooker.utils.pipeline.convert import HTML5ConversionHandler
 from ricecooker.utils.pipeline.convert import KPUBConversionHandler
+from ricecooker.utils.pipeline.convert import VideoCompressionHandler
 from ricecooker.utils.pipeline.exceptions import InvalidFileException
 
 
 def test_html5_archive_with_mp4_compression(video_file, audio_file):
-    """Test that MP4 and MP3 files within HTML5 archives are compressed when compression is enabled."""
+    """Test that MP4 and MP3 files within HTML5 archives are compressed when settings are provided."""
     # Create temporary HTML5 archive with media files
     temp_archive = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     temp_archive.close()
@@ -41,10 +42,15 @@ def test_html5_archive_with_mp4_compression(video_file, audio_file):
             mock_video_compress.return_value = None
             mock_audio_compress.return_value = None
 
-            # Process the HTML5 file with compression enabled
-            with patch("ricecooker.config.COMPRESS", True):
-                html_file = HTMLZipFile(temp_archive.name)
-                result = html_file.process_file()
+            # Process the HTML5 file with compression settings provided
+            result = HTML5ConversionHandler().execute(
+                temp_archive.name,
+                context={
+                    "video_settings": {"crf": 32},
+                    "audio_settings": {"bit_rate": 96},
+                },
+                skip_cache=True,
+            )
 
             # Verify both compression functions were called
             assert mock_video_compress.called, (
@@ -60,7 +66,7 @@ def test_html5_archive_with_mp4_compression(video_file, audio_file):
 
 
 def test_h5p_archive_with_webm_compression(video_file):
-    """Test that WebM files within H5P archives are compressed when compression is enabled."""
+    """Test that WebM files within H5P archives are compressed when settings are provided."""
     # Create temporary H5P archive with WebM file
     temp_archive = tempfile.NamedTemporaryFile(suffix=".h5p", delete=False)
     temp_archive.close()
@@ -77,10 +83,12 @@ def test_h5p_archive_with_webm_compression(video_file):
             # Mock successful compression
             mock_compress.return_value = None
 
-            # Process the H5P file with compression enabled
-            with patch("ricecooker.config.COMPRESS", True):
-                h5p_file = H5PFile(temp_archive.name)
-                result = h5p_file.process_file()
+            # Process the H5P file with compression settings provided
+            result = H5PConversionHandler().execute(
+                temp_archive.name,
+                context={"video_settings": {"crf": 32}},
+                skip_cache=True,
+            )
 
             # Verify compression was called
             assert mock_compress.called, (
@@ -92,8 +100,8 @@ def test_h5p_archive_with_webm_compression(video_file):
         os.unlink(temp_archive.name)
 
 
-def test_archive_no_compression_when_disabled(video_file, audio_file):
-    """Test that media files are not compressed when compression is disabled."""
+def test_archive_no_compression_without_settings(video_file, audio_file):
+    """Test that archive media files are not compressed without explicit settings."""
     # Create temporary HTML5 archive with media files
     temp_archive = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     temp_archive.close()
@@ -114,22 +122,44 @@ def test_archive_no_compression_when_disabled(video_file, audio_file):
                 "ricecooker.utils.pipeline.convert.compress_audio"
             ) as mock_audio_compress,
         ):
-            # Process the HTML5 file with compression disabled
-            with patch("ricecooker.config.COMPRESS", False):
-                html_file = HTMLZipFile(temp_archive.name)
-                result = html_file.process_file()
+            # Process the HTML5 file without compression settings
+            result = HTML5ConversionHandler().execute(
+                temp_archive.name, skip_cache=True
+            )
 
             # Verify compression functions were not called
             assert not mock_video_compress.called, (
-                "Video compression should not be called when disabled"
+                "Video compression should not be called without explicit settings"
             )
             assert not mock_audio_compress.called, (
-                "Audio compression should not be called when disabled"
+                "Audio compression should not be called without explicit settings"
             )
             assert result is not None, "Processing should still succeed"
 
     finally:
         os.unlink(temp_archive.name)
+
+
+def test_video_handler_only_validates_without_settings(video_file):
+    """Standalone media files are only validated when no explicit compression
+    settings are provided."""
+    with patch("ricecooker.utils.pipeline.convert.compress_video") as mock_compress:
+        VideoCompressionHandler().execute(video_file.path, skip_cache=True)
+
+    assert not mock_compress.called, (
+        "Video compression should not be called without explicit settings"
+    )
+
+
+def test_audio_handler_only_validates_without_settings(audio_file):
+    """Standalone media files are only validated when no explicit compression
+    settings are provided."""
+    with patch("ricecooker.utils.pipeline.convert.compress_audio") as mock_compress:
+        AudioCompressionHandler().execute(audio_file.path, skip_cache=True)
+
+    assert not mock_compress.called, (
+        "Audio compression should not be called without explicit settings"
+    )
 
 
 # HTML5 Conversion Tests

--- a/tests/pipeline/test_file_handler.py
+++ b/tests/pipeline/test_file_handler.py
@@ -1,7 +1,10 @@
+import shutil
 import threading
+from unittest.mock import patch
 
 import pytest
 
+from ricecooker.utils.pipeline import FilePipeline
 from ricecooker.utils.pipeline.context import FileMetadata
 from ricecooker.utils.pipeline.exceptions import InvalidFileException
 from ricecooker.utils.pipeline.file_handler import FileHandler
@@ -87,3 +90,33 @@ def test_output_path_thread_safety():
     # Each thread should get its own correct path, not interfere with each other
     assert results["A"] == "/storage/file_A.txt"
     assert results["B"] == "/storage/file_B.txt"
+
+
+def _fake_compress(path, outpath, overwrite=True, **settings):
+    shutil.copyfile(path, outpath)
+
+
+def test_file_pipeline_default_context_supplies_compression_settings(video_file):
+    """Settings in the pipeline's default_context are passed to handlers."""
+    pipeline = FilePipeline(default_context={"video_settings": {"crf": 30}})
+    with patch(
+        "ricecooker.utils.pipeline.convert.compress_video", side_effect=_fake_compress
+    ) as mock_compress:
+        pipeline.execute(video_file.path, skip_cache=True)
+
+    assert mock_compress.called, "Video compression should use default context settings"
+    assert mock_compress.call_args.kwargs["crf"] == 30
+
+
+def test_file_pipeline_execute_context_overrides_default_context(video_file):
+    """Context passed to execute() takes precedence over default_context."""
+    pipeline = FilePipeline(default_context={"video_settings": {"crf": 30}})
+    with patch(
+        "ricecooker.utils.pipeline.convert.compress_video", side_effect=_fake_compress
+    ) as mock_compress:
+        pipeline.execute(
+            video_file.path, context={"video_settings": {"crf": 24}}, skip_cache=True
+        )
+
+    assert mock_compress.called
+    assert mock_compress.call_args.kwargs["crf"] == 24

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1253,11 +1253,10 @@ def test_video_compression_cache_keys_with_settings(
 def test_video_compression_cache_keys_no_settings(
     mock_filecache, video_file, video_filename
 ):
-    """Test cache key generation for video compression with default settings"""
+    """Test cache key generation for video compression without settings"""
     path = video_file.path
     video = VideoFile(path)
-    with patch("ricecooker.utils.pipeline.convert.config.COMPRESS", True):
-        video.process_file()
+    video.process_file()
 
     expected_keys = {
         f"DOWNLOAD:{path}",
@@ -1292,11 +1291,10 @@ def test_audio_compression_cache_keys_with_settings(
 def test_audio_compression_cache_keys_no_settings(
     mock_filecache, audio_file, audio_filename
 ):
-    """Test cache key generation for audio compression with default settings"""
+    """Test cache key generation for audio compression without settings"""
     path = audio_file.path
     audio = AudioFile(path)
-    with patch("ricecooker.utils.pipeline.convert.config.COMPRESS", True):
-        audio.process_file()
+    audio.process_file()
 
     expected_keys = {
         f"DOWNLOAD:{path}",


### PR DESCRIPTION
## Summary

Compression was driven by the `config.COMPRESS` global, which handlers consulted at processing time. Now `FilePipeline` accepts a `default_context` merged into every `execute()` call, and `SushiChef.run` builds explicit video/audio settings from the `--compress` flag and passes them through it. All handlers — standalone media and archive — compress only when explicit settings are provided.

`config.COMPRESS` is removed since nothing reads it anymore. **Breaking** for any external chef script that read `config.COMPRESS` directly; the `--compress` CLI flag itself behaves as before.

## References

Extracted from in-progress spreadsheet chef work; no linked issue.

## Reviewer guidance

`uv run --group test pytest tests/pipeline/ tests/test_files.py`

Areas worth a careful look:
- Behavior change: with `--compress`, standalone media previously compressed with ffmpeg defaults; now `run()` supplies `crf: 32` / `max_height` / `bit_rate: 96` explicitly — check those defaults are the ones we want
- `ArchiveProcessingBaseHandler.get_cache_key` now keys on settings presence rather than `config.COMPRESS` — affects which cached results get reused across runs with different flags

## AI usage

I used Claude Code to extract this change from a larger working branch and add the tests; tests were verified to fail against the old `config.COMPRESS` gating, and I reviewed the final diff.