### PR TITLE
Fix setuptools-scm pyproject section name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
     "ruff>=0.11",
 ]
 
-[tool.setuptools-scm]
+[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 include = ["ricecooker*"]


### PR DESCRIPTION
## Summary

Builds produce version 0.0.0 because the section is named `[tool.setuptools-scm]`; setuptools-scm only recognizes `[tool.setuptools_scm]`. A 0.0.0 install fails Studio's version check, and `uv build` in the publish workflow would be affected the same way.

## References

Introduced in #663.

## Reviewer guidance

`uv sync --reinstall-package ricecooker && uv run python -c "import ricecooker; print(ricecooker.__version__)"` — prints 0.0.0 before, a real scm version after.

## AI usage

Claude Code found the root cause while debugging a chef run and made the one-line fix; I verified the rebuilt version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)