### PR TITLE
Always generate thumbnails for content nodes and topics

### DIFF
--- a/docs/chefops.md
+++ b/docs/chefops.md
@@ -10,7 +10,7 @@ Ricecooker CLI
 This listing shows the `ricecooker` command line interface (CLI) arguments:
 
     usage: sushichef.py  [-h] [--token TOKEN] [-u] [-v] [--quiet] [--warn]
-                            [--debug] [--compress] [--thumbnails]
+                            [--debug] [--compress]
                             [--resume]  [--step {CONSTRUCT_CHANNEL, CREATE_TREE,
                                                  DOWNLOAD_FILES, GET_FILE_DIFF,
                                                  START_UPLOAD, UPLOAD_CHANNEL}]
@@ -25,7 +25,6 @@ This listing shows the `ricecooker` command line interface (CLI) arguments:
       --debug               Print extra debugging infomation.
       -v, --verbose         Verbose mode (default).
       --compress            Compress videos using ffmpeg -crf=32 -b:a 32k mono.
-      --thumbnails          Automatically generate thumbnails for content nodes.
       --resume              Resume chef session from a specified step.
       --step  {INIT, ...    Step to resume progress from (must be used with --resume flag)
       --update              Force re-download of files (skip .ricecookerfilecache/ check)
@@ -40,12 +39,11 @@ the complete list: you'll have to run `./sushichef.py -h` to see the latest vers
 Below is a short guide to some of the most important and useful ones arguments.
 
 
-### Compression and thumbnail globals
-You can specify video compression settings (see this page) and thumbnails for
-specific nodes and files in the channel, or use `--compress` and `--thumbnails`
-to apply compression to ALL videos, and automatically generate thumbnails for
-all the supported content kinds. **We recommend you always use the `--thumbnails`**
-in order to create more colorful, lively channels that learners will want to browse.
+### Compression globals
+You can specify video compression settings for specific nodes and files in the
+channel, or use `--compress` to apply compression to ALL videos.
+Thumbnails are always generated automatically for any content node or topic that
+doesn't have a thumbnail provided — no flag is needed.
 
 
 ### Caching
@@ -138,6 +136,6 @@ time to complete so it is best to run them on a dedicated server for this purpos
   - Clone the sushi chef git repository in the `/data` folder on the server
   - Run the chef script as follows `nohup <chef cmd> &`, where `<chef cmd>`
     is contains the entire script name and command line options,
-    e.g. `./sushichef.py --token=... --thumbnails lang=fr`.
+    e.g. `./sushichef.py --token=... lang=fr`.
   - By default `nohup` logs stderr and stdout output to a file called `nohup.out`
     in the current working directory. Use `tail -f nohup.out` to follow this log file.

--- a/docs/developer/design_cli.md
+++ b/docs/developer/design_cli.md
@@ -113,7 +113,7 @@ There are three types of arguments involved in a chef run:
   - `args` (dict): command line args as parsed by the sushi chef class and its parents
     - SushiChef: the `SushiChef.__init__` method configures argparse for the following:
         - `compress`, `download_attempts`, `prompt`, `publish`, `resume`,
-          `stage`, `step`, `thumbnails`, `token`, `update`, `verbose`, `warn`
+          `stage`, `step`, `token`, `update`, `verbose`, `warn`
     - MySushiChef: the chef's `__init__` method can define additional cli args
 
   - `options` (dict): additional [OPTIONS...] passed at the end of the command line

--- a/docs/developer/uploadprocess.md
+++ b/docs/developer/uploadprocess.md
@@ -44,10 +44,11 @@ Each `Node` subclass implements the `process_files` method which includes the
 following steps:
   - call `process_file` on all files associated with the node (described below)
   - if the node has children, `process_files` is called on all child nodes
-  - call the node's `generate_thumbnail` method if it doesn't have a thumbnail
-    already, and the node has `derive_thumbnail` set to True, or if the global
-    command line argument `--thumbnail` (config.THUMBNAILS) is set to True.
-    See notes section "Node.generate_thumbnail".
+  - for content nodes: call `generate_missing_thumbnail` when no thumbnail has been
+    provided, generating one automatically from the node's content files.
+    Topic nodes skip this step; their thumbnails are generated in a separate
+    post-pass by `ChannelManager.generate_deferred_thumbnails()`, which runs after
+    all nodes have been processed and tiles the thumbnails of descendant content nodes.
 
 The result of the `node.process_file()` is a list of processed filenames, that
 reference files in the content-addressable storage directory `/content/storage/`.

--- a/docs/examples/languages.ipynb
+++ b/docs/examples/languages.ipynb
@@ -406,7 +406,6 @@
     "            source_id=youtube_id,\n",
     "            title='Youtube video',\n",
     "            license=TE_LICENSE,\n",
-    "            derive_thumbnail=True,\n",
     "            files=[YouTubeVideoFile(youtube_id=youtube_id)],\n",
     "        )\n",
     "\n",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,8 +152,7 @@ Use the links below to jump to the specific topics that you want to learn about.
 
 `Command line interface <chefops.html#ricecooker-cli>`_
 *******************************************************
-Use command line options like ``--thumbnails`` (auto-generating thumbnails),
-and ``--compress`` (video compression) to create better channels.
+Use command line options like ``--compress`` (video compression) to create better channels.
 
 
 .. rst-class:: column column3

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -70,7 +70,6 @@ Each node has the following attributes:
   - __learner_needs__ (list[str]): Specific learning needs the content is suitable for. Expects a list of constants from `le_utils.constants.labels.needs`. Example: `from le_utils.constants.labels import needs; node.learner_needs = [needs.PRIOR_KNOWLEDGE_REMEDIATION]`. (optional)
   - __accessibility_labels__ (list[str]): Accessibility features provided by the content. Expects a list of constants from `le_utils.constants.labels.accessibility_categories`. Example: `from le_utils.constants.labels import accessibility_categories; node.accessibility_labels = [accessibility_categories.CAPTIONS_SUBTITLES]`. (optional)
   - __thumbnail__ (str or ThumbnailFile): path to thumbnail or file object (optional)
-  - __derive_thumbnail__ (bool): set to True to generate thumbnail from contents (optional)
   - __files__ ([FileObject]): list of file objects for node (optional)
   - __extra_fields__ (dict): any additional data needed for node (optional)
   - __domain_ns__ (uuid): who is providing the content (e.g. learningequality.org) (optional)
@@ -142,8 +141,7 @@ See [languages][./languages.md] to read more about language codes.
 Thumbnails can be passed in as a local filesystem path to an image file (str),
 a URL (str), or a `ThumbnailFile` object.
 The recommended size for thumbnail images is 400px by 225px (aspect ratio 16:9).
-Use the command line argument `--thumbnails` to automatically generate thumbnails
-for all content node that don't have a thumbnail specified.
+Thumbnails are automatically generated for all content nodes and topics that don't have a thumbnail specified.
 
 
 
@@ -166,9 +164,8 @@ Topic nodes are folder-like containers that are used to organize the channel's c
 
 It is highly recommended to find suitable thumbnail images for topic nodes. The
 presence of thumbnails will make the content more appealing and easier to browse.
-Set `derive_thumbnail=True` on a topic node or use the `--thumbnails` command
-line argument and Ricecooker will generate thumbnails for topic nodes based on
-the thumbnails of the content nodes they contain.
+When no thumbnail is provided for a topic node, Ricecooker automatically generates
+a tiled thumbnail by compositing the thumbnails of its descendant content nodes.
 
 
 
@@ -214,9 +211,9 @@ and the files will be downloaded for you automatically.
 You can replace `DocumentNode` and `DocumentFile` with any of the other combinations
 of content node and file types.
 
-Specify `derive_thumbnail=True` and leave thumbnail blank (`thumbnail=None`) to
-let Ricecooker automatically generate a thumbnail for the node based on its content.
-Thumbnail generation is supported for audio, video, PDF, and ePub, and HTML5 files.
+Leaving `thumbnail=None` (the default) causes Ricecooker to automatically generate
+a thumbnail for the node based on its content.
+Thumbnail generation is supported for video, PDF, ePub, and HTML5 files.
 
 
 

--- a/examples/oldexamples/sample_program.py
+++ b/examples/oldexamples/sample_program.py
@@ -382,7 +382,6 @@ def _build_tree(node, sourcetree):
                 ),
                 author=child_source_node.get("author"),
                 description=child_source_node.get("description"),
-                derive_thumbnail=True,  # video-specific data
                 thumbnail=child_source_node.get("thumbnail"),
             )
             add_files(child_node, child_source_node.get("files") or [])

--- a/examples/oldexamples/wikipedia_video_chef.py
+++ b/examples/oldexamples/wikipedia_video_chef.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
 
 
 # Run the chef using
-#   ./wikipedia_video_chef.py  --thumbnails --token=<yourstudiotoken>
+#   ./wikipedia_video_chef.py  --token=<yourstudiotoken>
 # and you should see something like:
 #
 #    Downloading https://commons.wikimedia.org/w/api.php?action=timedtext&title=File%3AA_Is_for_Atom_1953.webm&lang=en&trackformat=srt

--- a/ricecooker/chefs.py
+++ b/ricecooker/chefs.py
@@ -64,19 +64,22 @@ class SushiChef(object):
         if not hasattr(self, "SETTINGS"):
             self.SETTINGS = {}
         else:
-            if "generate-missing-thumbnails" in self.SETTINGS:
-                warning_text = "thumbnails setting is deprecated and will be replaced by thumbnails in version 0.8 please update"
-                config.LOGGER.warn(warning_text)
-                warn(warning_text, DeprecationWarning)
-                self.SETTINGS["thumbnails"] = self.SETTINGS[
-                    "generate-missing-thumbnails"
-                ]
-
             if "compress-videos" in self.SETTINGS:
                 warning_text = "compress-videos setting is deprecated and will be replaced by compress in version 0.8 please update"
                 config.LOGGER.warn(warning_text)
                 warn(warning_text, DeprecationWarning)
                 self.SETTINGS["compress"] = self.SETTINGS["compress-videos"]
+
+            for thumbnail_setting in ("thumbnails", "generate-missing-thumbnails"):
+                if thumbnail_setting in self.SETTINGS:
+                    warning_text = (
+                        "{} setting is deprecated and is ignored: thumbnails are now always "
+                        "generated for nodes that do not provide one".format(
+                            thumbnail_setting
+                        )
+                    )
+                    config.LOGGER.warning(warning_text)
+                    warn(warning_text, DeprecationWarning)
 
         # these will be assigned to later by the argparse handling.
         self.args = None
@@ -130,11 +133,6 @@ class SushiChef(object):
             "--compress",
             action="store_true",
             help="Compress videos using ffmpeg -crf=32 -b:a 32k mono.",
-        )
-        parser.add_argument(
-            "--thumbnails",
-            action="store_true",
-            help="Automatically generate thumbnails for content nodes.",
         )
         parser.add_argument(
             "--download-attempts",
@@ -191,6 +189,15 @@ class SushiChef(object):
                 " Uploading a staging tree is now the default behavior. Use --deploy to upload to the main tree."
             ),
         )
+        parser.add_argument(
+            "--thumbnails",
+            dest="thumbnails_deprecated",
+            action="store_true",
+            help=(
+                "(deprecated) Thumbnails are now always generated"
+                " for content nodes and topics that do not provide one."
+            ),
+        )
 
         # [OPTIONS] --- extra key=value options are supported, but do not appear in help
 
@@ -211,10 +218,7 @@ class SushiChef(object):
 
         override = None
         # If there is a command line flag for this setting, allow for it to override the chef
-        # default. Note that these are all boolean flags, so they are true if set, false if not.
-        if setting == "thumbnails":
-            override = self.args and self.args["thumbnails"]
-
+        # default. Note that the compress flag is a boolean: true if set on the command line, false if not.
         if setting == "compress":
             override = self.args and self.args["compress"]
 
@@ -257,6 +261,11 @@ class SushiChef(object):
         if args["reset_deprecated"]:
             config.LOGGER.warning(
                 "DEPRECATION WARNING: --reset is now the default bevavior. The --reset flag has been deprecated and will be removed in ricecooker 1.0."
+            )
+        if args["thumbnails_deprecated"]:
+            config.LOGGER.warning(
+                "DEPRECATION WARNING: thumbnails are now always generated for content nodes and topics that do not provide one. "
+                "The --thumbnails flag has been deprecated and will be removed in ricecooker 1.0."
             )
         if args["publish"] and args["stage"]:
             raise InvalidUsageException(

--- a/ricecooker/classes/files.py
+++ b/ricecooker/classes/files.py
@@ -9,7 +9,6 @@ from le_utils.constants import languages
 from requests import HTTPError
 
 from .. import config
-from ..exceptions import UnknownFileTypeError
 from ricecooker.utils.caching import FILECACHE
 from ricecooker.utils.caching import get_cache_filename
 from ricecooker.utils.images import create_image_from_epub
@@ -22,6 +21,7 @@ from ricecooker.utils.pipeline.convert import AudioCompressionHandler
 from ricecooker.utils.pipeline.convert import ImageConversionHandler
 from ricecooker.utils.pipeline.convert import SubtitleConversionHandler
 from ricecooker.utils.pipeline.convert import VideoCompressionHandler
+from ricecooker.utils.pipeline.context import NODE_HAS_THUMBNAIL
 from ricecooker.utils.pipeline.exceptions import ExpectedFileException
 from ricecooker.utils.pipeline.exceptions import InvalidFileException
 from ricecooker.utils.pipeline.transfer import CatchAllWebResourceDownloadHandler
@@ -35,14 +35,16 @@ fallback_pipeline = FilePipeline()
 # Lookup table for convertible file formats for a given preset
 # used for converting avi/flv/etc. videos and srt subtitles
 CONVERTIBLE_FORMATS = {p.id: p.convertible_formats for p in format_presets.PRESETLIST}
+PRESET_LOOKUP = {p.id: p for p in format_presets.PRESETLIST}
 
 
 class ThumbnailPresetMixin(object):
     def get_preset(self):
-        thumbnail_preset = self.node.get_thumbnail_preset()
-        if thumbnail_preset is None:
-            UnknownFileTypeError("Thumbnails are not supported for node kind.")
-        return thumbnail_preset
+        # May return None: the node's kind may not be known yet (a uri-based
+        # node before the pipeline has run), or may have no thumbnail preset
+        # (e.g. StudioContentNode, whose serialized thumbnail overrides rely
+        # on a None preset being resolved by Studio).
+        return self.node.get_thumbnail_preset()
 
 
 class File(object):
@@ -99,6 +101,27 @@ class File(object):
             f"preset must be set if preset and default_preset isn't specified when creating {self.__class__.__name__} "
             f"object for file {self.filename} ({self.original_filename})"
         )
+
+    def is_thumbnail(self):
+        """
+        Whether this file is a thumbnail, based on its format preset.
+        Returns False when the preset cannot be resolved (a ThumbnailFile not yet attached to a node, or a File with no preset).
+        """
+        try:
+            # For ThumbnailPresetMixin files this may resolve to None (kind
+            # not yet known, or no thumbnail preset for the kind), which the
+            # PRESET_LOOKUP check below maps to False.
+            preset = self.get_preset()
+        except NotImplementedError:
+            # File with no preset and no default_preset.
+            return False
+        except AttributeError:
+            if self.node is None:
+                # ThumbnailFile (ThumbnailPresetMixin) not yet attached to a node.
+                return False
+            raise
+        preset_obj = PRESET_LOOKUP.get(preset)
+        return bool(preset_obj and preset_obj.thumbnail)
 
     def get_filename(self):
         return self.filename or self.process_file()
@@ -209,8 +232,14 @@ class DownloadFile(File):
             except ValueError as ve:
                 raise InvalidFileException from ve
             pipeline = config.FILE_PIPELINE or fallback_pipeline
+            # This legacy path only consumes the first (source) metadata entry,
+            # and thumbnails for legacy nodes are generated at the node level
+            # (generate_missing_thumbnail), so always skip the pipeline
+            # thumbnail stage rather than generate an image only to discard it.
+            context = dict(self.context)
+            context[NODE_HAS_THUMBNAIL] = True
             metadata = pipeline.execute(
-                self.path, context=self.context, skip_cache=config.UPDATE
+                self.path, context=context, skip_cache=config.UPDATE
             )[0]
             metadata = metadata.to_dict()
             for key in metadata:
@@ -536,7 +565,7 @@ class ExtractedThumbnailFile(ThumbnailFile):
 
 
 class ExtractedPdfThumbnailFile(ExtractedThumbnailFile):
-    extractor_kwargs = {"page_number": 0, "crop": None}
+    extractor_kwargs = {"page_number": 0, "crop": None, "max_width": 1000}
     allowed_formats = DocumentFile.allowed_formats
 
     def extractor_fun(self, fpath_in, thumbpath_out, **kwargs):
@@ -573,16 +602,25 @@ class TiledThumbnailFile(ThumbnailPresetMixin, File):
     def __init__(self, source_nodes, **kwargs):
         self.sources = []
         for n in source_nodes:
-            images = [
-                f for f in n.files if isinstance(f, ThumbnailFile) and f.get_filename()
-            ]
-            if len(images) > 0:
-                self.sources.append(images[0])
+            # Check f.filename directly (not get_filename()) so a thumbnail
+            # that failed to process is skipped rather than re-processed here.
+            image = next((f for f in n.files if f.is_thumbnail() and f.filename), None)
+            if image:
+                self.sources.append(image)
         super(TiledThumbnailFile, self).__init__(**kwargs)
 
     def process_file(self):
-        self.filename = self.generate_tiled_image()
-        config.LOGGER.info("\t--- Tiled image {}".format(self.filename))
+        try:
+            self.filename = self.generate_tiled_image()
+            if self.filename:
+                config.LOGGER.info("\t--- Tiled image {}".format(self.filename))
+            else:
+                config.LOGGER.info("\t--- No source thumbnails to tile")
+        except ThumbnailGenerationError as err:
+            config.LOGGER.warning("\t    Failed to generate tiled image {}".format(err))
+            self.filename = None
+            self.error = str(err)
+            config.FAILED_FILES.append(self)
         return self.filename
 
     def generate_tiled_image(self):

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -27,17 +27,19 @@ from .files import ExtractedEPubThumbnailFile
 from .files import ExtractedHTMLZipThumbnailFile
 from .files import ExtractedPdfThumbnailFile
 from .files import File
+from .files import PRESET_LOOKUP
 from .files import SubtitleFile
+from .files import ThumbnailFile
 from .files import YouTubeSubtitleFile
 from .licenses import License
 from .questions import VARIANT_A
 from .questions import VARIANT_B
+from ricecooker.utils.pipeline.context import NODE_HAS_THUMBNAIL
 from ricecooker.utils.pipeline.exceptions import ExpectedFileException
 from ricecooker.utils.pipeline.exceptions import InvalidFileException
 
 MASTERY_MODELS = [id for id, name in exercises.MASTERY_MODELS]
 ROLES = [id for id, name in roles.choices]
-PRESET_LOOKUP = {p.id: p for p in format_presets.PRESETLIST}
 
 
 # Used to map content kind to learning activity when a list of learning_activiies is not provided
@@ -96,7 +98,6 @@ class Node(object):
         description (str): description of the content (optional)
         thumbnail (str or ThumbnailFile): local path, url, or ThumbnailFile for thumbnail (optional)
         files ([File]): list of File objects for the node (optional)
-        derive_thumbnail (bool): whether to auto-generate thumbnail from content (default False)
         node_modifications (dict): modifications passed in by CSV import (optional)
         extra_fields (dict): additional data needed for the node (optional)
         suggested_duration (int): suggested duration in seconds (optional)
@@ -106,6 +107,10 @@ class Node(object):
     license = None
     language = None
     valid = False
+    # When True, thumbnail generation is deferred to the tree manager's
+    # post-pass, after all descendants have been processed (topics need
+    # their children's thumbnails to build a tiled image).
+    defer_thumbnail_generation = False
     # Nodes with questions (ExerciseNode, UnitNode) set this True.
     # This gates Node._validate() to allow a non-empty `questions` list,
     # which TreeNode.to_dict() serializes for the Studio API.
@@ -134,7 +139,6 @@ class Node(object):
         description=None,
         thumbnail=None,
         files=None,
-        derive_thumbnail=False,
         node_modifications={},
         extra_fields=None,
         suggested_duration=None,
@@ -151,7 +155,6 @@ class Node(object):
         self.title = title
         self.set_language(language)
         self.description = description or ""
-        self.derive_thumbnail = derive_thumbnail
         self.extra_fields = extra_fields or {}
 
         for f in files or []:
@@ -261,10 +264,13 @@ class Node(object):
         return None
 
     def has_thumbnail(self):
-        from .files import ThumbnailFile
-
-        return any(f for f in self.files if isinstance(f, ThumbnailFile))
-        # TODO deep check: f.process_file() and check f.filename is not None
+        """
+        Whether this node already has a thumbnail: either one was provided
+        explicitly (self.thumbnail), or one of its files has a thumbnail
+        format preset. The explicit self.thumbnail check handles uri-based nodes,
+        which have no kind until the pipeline runs.
+        """
+        return self.thumbnail is not None or any(f.is_thumbnail() for f in self.files)
 
     def set_thumbnail(self, thumbnail):
         """set_thumbnail: Set node's thumbnail
@@ -273,8 +279,6 @@ class Node(object):
         """
         self.thumbnail = thumbnail
         if isinstance(self.thumbnail, str):
-            from .files import ThumbnailFile
-
             self.thumbnail = ThumbnailFile(path=self.thumbnail)
 
         if self.thumbnail:
@@ -287,6 +291,11 @@ class Node(object):
         """
         if isinstance(self, ChannelNode):
             return format_presets.CHANNEL_THUMBNAIL
+        if self.kind is None:
+            # A kind-less node (e.g. a uri-based node before the pipeline has
+            # run) would otherwise wrongly match the channel_thumbnail preset,
+            # whose kind is also None.
+            return None
         try:
             preset = next(
                 filter(
@@ -298,29 +307,36 @@ class Node(object):
         except StopIteration:
             return None
 
-    def process_files(self):
-        """Processes all the files associated with this Node, including:
-        - download files if not present in the local storage
-        - convert and compress video files
-        - (optionally) generate thumbnail file from the node's content
-        Returns: content-hash based filenames of all the files for this node
+    def generate_missing_thumbnail(self):
+        """
+        Generate and attach a thumbnail if this node doesn't already have one.
+        Returns: list of generated thumbnail filenames (empty if nothing was
+        generated - node already has a thumbnail, not implemented for this
+        kind, no suitable source file, or generation failed).
         """
         filenames = []
-        for file in self.files:
-            filenames.append(file.process_file())
-
-        # Auto-generation of thumbnails happens here if derive_thumbnail or config.THUMBNAILS is set
-        if not self.has_thumbnail() and (config.THUMBNAILS or self.derive_thumbnail):
+        if not self.has_thumbnail():
             thumbnail_file = self.generate_thumbnail()
             if thumbnail_file:
                 thumbnail_filename = thumbnail_file.process_file()
                 if thumbnail_filename:
                     self.set_thumbnail(thumbnail_file)
                     filenames.append(thumbnail_filename)
-                else:
-                    pass  # failed to generate thumbnail
-            else:
-                pass  # method generate_thumbnail is not implemented or no suitable source file found
+        return filenames
+
+    def process_files(self):
+        """Processes all the files associated with this Node, including:
+        - download files if not present in the local storage
+        - convert and compress video files
+        - generate a thumbnail from the node's content when none is provided
+        Returns: content-hash based filenames of all the files for this node
+        """
+        filenames = []
+        for file in self.files:
+            filenames.append(file.process_file())
+
+        if not self.defer_thumbnail_generation:
+            filenames.extend(self.generate_missing_thumbnail())
 
         return filenames
 
@@ -799,13 +815,15 @@ class TreeNode(Node):
 class TopicNode(TreeNode):
     """Model representing topic nodes for organizing channel content.
 
-    Topic nodes create the folder structure of a channel. When derive_thumbnail
-    is True, generates a tiled thumbnail from descendant content nodes.
+    Topic nodes create the folder structure of a channel. A tiled thumbnail is
+    generated from descendants after all of them have been processed, unless a
+    thumbnail was provided.
 
     See TreeNode and Node for inherited attributes.
     """
 
     kind = content_kinds.TOPIC
+    defer_thumbnail_generation = True
 
     def generate_thumbnail(self):
         """Generate a ``TiledThumbnailFile`` based on the descendants.
@@ -913,9 +931,17 @@ class ContentNode(TreeNode):
         return super(ContentNode, self)._validate()
 
     def _process_uri(self):
+        # has_thumbnail() cannot resolve a ThumbnailFile's kind-dependent
+        # preset before the pipeline has set this node's kind, so also count
+        # provided ThumbnailFile instances (e.g. passed via files=[...]).
+        has_thumbnail = self.has_thumbnail() or any(
+            isinstance(f, ThumbnailFile) for f in self.files
+        )
         try:
             file_metadata_list = self.pipeline.execute(
-                self.uri, skip_cache=config.UPDATE
+                self.uri,
+                context={NODE_HAS_THUMBNAIL: has_thumbnail},
+                skip_cache=config.UPDATE,
             )
         except (InvalidFileException, ExpectedFileException) as e:
             config.LOGGER.error(f"Error processing path: {self.uri} with error: {e}")
@@ -980,9 +1006,6 @@ class VideoNode(ContentNode):
     """Model representing videos in channel
 
     Videos must be mp4 or webm format
-
-    Attributes:
-        derive_thumbnail (bool): set to generate thumbnail from video (optional)
 
     See ContentNode for inherited attributes.
     """
@@ -1051,9 +1074,6 @@ class DocumentNode(ContentNode):
 
     Documents must be in PDF, ePub, Bloom, or KPUB format
 
-    Attributes:
-        derive_thumbnail (bool): automatically generate thumbnail (optional)
-
     See ContentNode for inherited attributes.
     """
 
@@ -1098,7 +1118,6 @@ class HTML5AppNode(ContentNode):
 
     Attributes:
         entrypoint (str): custom entry point file (optional, defaults to index.html)
-        derive_thumbnail (bool): generate thumbnail from largest image inside zip (optional)
 
     See ContentNode for inherited attributes.
     """

--- a/ricecooker/commands.py
+++ b/ricecooker/commands.py
@@ -31,7 +31,6 @@ def uploadchannel(  # noqa: C901
     chef,
     command="uploadchannel",
     update=False,
-    thumbnails=False,
     download_attempts=3,
     resume=False,
     step=Status.LAST.name,
@@ -47,7 +46,6 @@ def uploadchannel(  # noqa: C901
         chef (SushiChef subclass): class that implements the construct_channel method
         command (str): the action we want to perform in this run
         update (bool): indicates whether to re-download files (optional)
-        thumbnails (bool): indicates whether to automatically derive thumbnails from content (optional)
         download_attempts (int): number of times to retry downloading files (optional)
         resume (bool): indicates whether to resume last session automatically (optional)
         step (str): step to resume process from (optional)
@@ -64,7 +62,6 @@ def uploadchannel(  # noqa: C901
     config.UPDATE = update
     config.COMPRESS = chef.get_setting("compress", False)
     config.VIDEO_HEIGHT = chef.get_setting("video-height", None)
-    config.THUMBNAILS = chef.get_setting("thumbnails", False)
     config.STAGE = stage
     config.PUBLISH = publish
     config.FILE_PIPELINE = chef.file_pipeline

--- a/ricecooker/config.py
+++ b/ricecooker/config.py
@@ -17,7 +17,6 @@ from requests_file import FileAdapter
 UPDATE = False
 COMPRESS = False
 VIDEO_HEIGHT = None
-THUMBNAILS = False
 PUBLISH = False
 PROGRESS_MANAGER = None
 SUSHI_BAR_CLIENT = None

--- a/ricecooker/managers/tree.py
+++ b/ricecooker/managers/tree.py
@@ -8,6 +8,7 @@ from requests.exceptions import RequestException
 
 from .. import config
 from ricecooker.exceptions import InvalidNodeException
+from ricecooker.utils.images import ThumbnailGenerationError
 
 
 class InsufficientStorageException(Exception):
@@ -72,6 +73,7 @@ class ChannelManager:
         ) as executor:
             for data in executor.map(self.process_node, self.all_nodes):
                 self.file_map.update(data)
+        self.generate_deferred_thumbnails()
         return list(self.file_map.keys())
 
     def gather_tree_recur(self, nodes, node):
@@ -79,7 +81,7 @@ class ChannelManager:
         for child_node in node.children:
             self.gather_tree_recur(
                 nodes, child_node
-            )  # Defer insert until after all descendants in case a tiled thumbnail is needed
+            )  # Insert after all descendants so generate_deferred_thumbnails can rely on children-first order
         nodes.append(node)
         return nodes
 
@@ -108,6 +110,31 @@ class ChannelManager:
                     if question_file.get_filename():
                         output[question_file.get_filename()] = question_file
         return output
+
+    def generate_deferred_thumbnails(self):
+        """
+        Generate thumbnails for nodes that defer generation until all their
+        descendants have been processed (topics). Runs sequentially after the
+        concurrent processing pass: self.all_nodes is ordered children-first,
+        so every descendant (and its generated thumbnail) is complete by the
+        time each ancestor is reached.
+        """
+        for node in self.all_nodes:
+            if not node.defer_thumbnail_generation:
+                continue
+            try:
+                new_filenames = node.generate_missing_thumbnail()
+            except ThumbnailGenerationError as e:
+                # Safety net: generation failures are normally recorded in
+                # config.FAILED_FILES by the file object and returned as None.
+                config.LOGGER.warning(
+                    "\tFailed to generate thumbnail for {}: {}".format(node.title, e)
+                )
+                continue
+            # Register the generated thumbnail (attached as node.thumbnail)
+            # so the upload pass knows about it.
+            for filename in new_filenames:
+                self.file_map[filename] = node.thumbnail
 
     def check_for_files_failed(self):
         """check_for_files_failed: print any files that failed during download process

--- a/ricecooker/utils/images.py
+++ b/ricecooker/utils/images.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import ebooklib.epub
 from pdf2image import convert_from_path
 from PIL import Image
+from PyPDF2 import PdfFileReader
 
 from .thumbscropping import scale_and_crop
 
@@ -107,14 +108,52 @@ def create_image_from_zip(htmlfile, fpath_out, crop="smart"):
         raise ThumbnailGenerationError("Fail on zip {} {}".format(htmlfile, e))
 
 
-def create_image_from_pdf_page(fpath_in, fpath_out, page_number=0, crop=None):
+def _pdf_page_width_px(fpath_in, page_number, dpi):
+    """
+    Native render width in pixels of the given pdf page at `dpi`, accounting
+    for page rotation, or None when the page dimensions cannot be read.
+    """
+    try:
+        # Open the file ourselves: PyPDF2 never closes streams it opens from
+        # a path string.
+        with open(fpath_in, "rb") as f:
+            # convert_from_path's page numbering is 1-based (0 is clamped to 1).
+            page = PdfFileReader(f, strict=False).getPage(max(page_number - 1, 0))
+            media_box = page.mediaBox
+            width_pts = float(media_box.getWidth())
+            if (page.get("/Rotate") or 0) % 180:
+                width_pts = float(media_box.getHeight())
+        return width_pts / 72 * dpi
+    except Exception:
+        return None
+
+
+def create_image_from_pdf_page(
+    fpath_in, fpath_out, page_number=0, crop=None, max_width=None
+):
     """
     Create an image from the pdf at fpath_in and write result to fpath_out.
+
+    Pass max_width to cap the rendered width (preserving aspect ratio);
+    this avoids enormous intermediate images for large-format pages.
+    Pages that would render narrower than max_width are not upscaled.
     """
     try:
         assert fpath_in.endswith("pdf"), "File must be in pdf format"
+        size = None
+        if max_width:
+            native_width = _pdf_page_width_px(fpath_in, page_number, 500)
+            # Cap, don't force: poppler's -scale-to-x renders at exactly the
+            # given width, so only pass it for pages that would render wider.
+            # When the page size can't be read, apply the cap defensively.
+            if native_width is None or native_width > max_width:
+                size = (max_width, None)
         pages = convert_from_path(
-            fpath_in, 500, first_page=page_number, last_page=page_number + 1
+            fpath_in,
+            500,
+            first_page=page_number,
+            last_page=page_number + 1,
+            size=size,
         )
         page = pages[0]
         # resize

--- a/ricecooker/utils/jsontrees.py
+++ b/ricecooker/utils/jsontrees.py
@@ -125,7 +125,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 # no role for topics (computed dynaically from descendants)
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get("derive_thumbnail", False),
                 tags=source_node.get("tags"),
             )
             parent_node.add_child(child_node)
@@ -144,7 +143,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 role=source_node.get("role", roles.LEARNER),
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get("derive_thumbnail", False),
                 tags=source_node.get("tags"),
             )
             add_files(child_node, source_node.get("files") or [])
@@ -162,7 +160,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 role=source_node.get("role", roles.LEARNER),
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get("derive_thumbnail", False),
                 tags=source_node.get("tags"),
             )
             add_files(child_node, source_node.get("files") or [])
@@ -180,9 +177,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 role=source_node.get("role", roles.LEARNER),
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get(
-                    "derive_thumbnail", False
-                ),  # not supported yet
                 tags=source_node.get("tags"),
                 exercise_data=source_node.get("exercise_data"),
                 questions=[],
@@ -219,7 +213,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 role=source_node.get("role", roles.LEARNER),
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get("derive_thumbnail", False),
                 tags=source_node.get("tags"),
             )
 
@@ -238,7 +231,6 @@ def build_tree_from_json(parent_node, sourcetree):
                 role=source_node.get("role", roles.LEARNER),
                 language=source_node.get("language"),
                 thumbnail=source_node.get("thumbnail"),
-                derive_thumbnail=source_node.get("derive_thumbnail", False),
                 tags=source_node.get("tags"),
             )
             add_files(child_node, source_node.get("files") or [])

--- a/ricecooker/utils/linecook.py
+++ b/ricecooker/utils/linecook.py
@@ -332,7 +332,6 @@ def make_content_node(channeldir, rel_path, filename, metadata):  # noqa: C901
             description=description,
             language=lang,
             license=license_dict,
-            derive_thumbnail=True,
             thumbnail=thumbnail_rel_path,
             files=[
                 {"file_type": VIDEO_FILE, "path": filepath, "language": lang}
@@ -349,7 +348,6 @@ def make_content_node(channeldir, rel_path, filename, metadata):  # noqa: C901
             language=lang,
             license=license_dict,
             thumbnail=thumbnail_rel_path,
-            derive_thumbnail=True,
             files=[{"file_type": AUDIO_FILE, "path": filepath, "language": lang}],
         )
 
@@ -363,7 +361,6 @@ def make_content_node(channeldir, rel_path, filename, metadata):  # noqa: C901
             language=lang,
             license=license_dict,
             thumbnail=thumbnail_rel_path,
-            derive_thumbnail=True,
             files=[],
         )
         if ext == "pdf":
@@ -385,7 +382,6 @@ def make_content_node(channeldir, rel_path, filename, metadata):  # noqa: C901
             language=lang,
             license=license_dict,
             thumbnail=thumbnail_rel_path,
-            derive_thumbnail=True,
             files=[{"file_type": HTML5_FILE, "path": filepath, "language": lang}],
         )
 
@@ -401,7 +397,6 @@ def make_content_node(channeldir, rel_path, filename, metadata):  # noqa: C901
             exercise_data=metadata["exercise_data"],
             questions=metadata["questions"],
             thumbnail=thumbnail_rel_path,
-            derive_thumbnail=False,
             files=[],
         )
 

--- a/ricecooker/utils/pipeline/__init__.py
+++ b/ricecooker/utils/pipeline/__init__.py
@@ -7,6 +7,7 @@ from typing import Optional
 from .convert import ConversionStageHandler
 from .extract_metadata import ExtractMetadataStageHandler
 from .file_handler import CompositeHandler
+from .thumbnails import ThumbnailStageHandler
 from .transfer import DownloadStageHandler
 from ricecooker.utils.pipeline.context import FileMetadata
 
@@ -37,18 +38,24 @@ class FilePipeline(CompositeHandler):
     from ricecooker.utils.pipeline import FilePipeline
     from ricecooker.utils.pipeline.convert import ConversionStageHandler
     from ricecooker.utils.pipeline.extract_metadata import ExtractMetadataStageHandler
+    from ricecooker.utils.pipeline.thumbnails import ThumbnailStageHandler
     from ricecooker.utils.pipeline.transfer import DownloadStageHandler
     from ricecooker.utils.pipeline.transfer import DiskResourceHandler
 
     download_stage = DownloadStageHandler(children=[DiskResourceHandler()])
-    pipeline = FilePipeline(children=[download_stage, ConversionStageHandler(), ExtractMetadataStageHandler()])
+    pipeline = FilePipeline(
+        children=[download_stage, ConversionStageHandler(), ThumbnailStageHandler(), ExtractMetadataStageHandler()]
+    )
     ```
+    Note: omitting ThumbnailStageHandler disables automatic thumbnail generation
+    for files processed by the pipeline.
     This will replace the default `DownloadStageHandler` with a new one that has a `DiskResourceHandler` as its only child.
     """
 
     DEFAULT_CHILDREN = [
         DownloadStageHandler,
         ConversionStageHandler,
+        ThumbnailStageHandler,
         ExtractMetadataStageHandler,
     ]
 

--- a/ricecooker/utils/pipeline/context.py
+++ b/ricecooker/utils/pipeline/context.py
@@ -4,6 +4,11 @@ from typing import Optional
 from typing import Type
 
 
+# Context key used by producers (nodes, chefs) to tell the thumbnail stage
+# that the node already has a thumbnail, so generation can be skipped.
+NODE_HAS_THUMBNAIL = "node_has_thumbnail"
+
+
 class AutoDataClassMetaClass(type):
     def __new__(mcs, name: str, bases: tuple, namespace: dict) -> Type:
         cls = super().__new__(mcs, name, bases, namespace)

--- a/ricecooker/utils/pipeline/file_handler.py
+++ b/ricecooker/utils/pipeline/file_handler.py
@@ -136,18 +136,21 @@ class FileHandler(Handler):
     def write_file(self, extension: str):
         """
         Context manager that provides a file handle to write to and handles copying to storage.
+
+        Copying to storage only happens when the body completes without raising:
+        an exception from the body propagates unchanged (rather than being masked
+        by the empty-file check) and a partially written file is discarded
+        instead of being copied to storage.
         """
         with DualModeTemporaryFile(ext=extension) as tempf:
-            try:
-                yield tempf
-            finally:
-                tempf.flush()
-                if not tempf.file_not_empty():
-                    raise InvalidFileException(
-                        f"File with extension {extension} failed to write (corrupted)."
-                    )
-                filename = copy_file_to_storage(tempf.name, ext=extension)
-                self._output_path = config.get_storage_path(filename)
+            yield tempf
+            tempf.flush()
+            if not tempf.file_not_empty():
+                raise InvalidFileException(
+                    f"File with extension {extension} failed to write (corrupted)."
+                )
+            filename = copy_file_to_storage(tempf.name, ext=extension)
+            self._output_path = config.get_storage_path(filename)
 
     @abstractmethod
     def handle_file(self, path, **kwargs) -> Union[None, FileMetadata]:

--- a/ricecooker/utils/pipeline/thumbnails.py
+++ b/ricecooker/utils/pipeline/thumbnails.py
@@ -1,0 +1,101 @@
+"""
+Pipeline stage that extracts thumbnail images from processed files.
+
+Runs after conversion, so it sees files in their final formats. For each
+supported file it emits an additional FileMetadata for the generated PNG
+with the appropriate thumbnail preset, alongside the source file.
+Generation is skipped when the node already provides a thumbnail (see the
+NODE_HAS_THUMBNAIL context key).
+
+Thumbnail generation is best-effort: if extraction fails, the source
+file passes through unaffected.
+"""
+
+from typing import Dict
+from typing import Optional
+
+from le_utils.constants import file_formats
+from le_utils.constants import format_presets
+
+from .file_handler import ExtensionMatchingHandler
+from .file_handler import StageHandler
+from ricecooker import config
+from ricecooker.utils.images import create_image_from_epub
+from ricecooker.utils.images import create_image_from_pdf_page
+from ricecooker.utils.images import create_image_from_zip
+from ricecooker.utils.images import ThumbnailGenerationError
+from ricecooker.utils.pipeline.context import ContextMetadata
+from ricecooker.utils.pipeline.context import FileMetadata
+from ricecooker.utils.pipeline.exceptions import ExpectedFileException
+from ricecooker.utils.pipeline.exceptions import InvalidFileException
+from ricecooker.utils.utils import extract_path_ext
+from ricecooker.utils.videos import extract_thumbnail_from_video
+
+
+THUMBNAIL_PRESETS = {
+    file_formats.PDF: format_presets.DOCUMENT_THUMBNAIL,
+    file_formats.EPUB: format_presets.DOCUMENT_THUMBNAIL,
+    file_formats.HTML5_ARTICLE: format_presets.DOCUMENT_THUMBNAIL,
+    file_formats.HTML5: format_presets.HTML5_THUMBNAIL,
+    file_formats.MP4: format_presets.VIDEO_THUMBNAIL,
+    file_formats.WEBM: format_presets.VIDEO_THUMBNAIL,
+}
+
+
+class ThumbnailContextMetadata(ContextMetadata):
+    node_has_thumbnail: bool = False
+
+
+class ThumbnailExtractionHandler(ExtensionMatchingHandler):
+    """Generates a PNG thumbnail from a processed file."""
+
+    EXTENSIONS = set(THUMBNAIL_PRESETS)
+
+    HANDLED_EXCEPTIONS = [ThumbnailGenerationError]
+
+    CONTEXT_CLASS = ThumbnailContextMetadata
+
+    def get_file_kwargs(self, context):
+        if context.node_has_thumbnail:
+            # The node already has a thumbnail; nothing to generate.
+            # Returning [] bypasses both cache lookup and generation
+            # entirely - any cached thumbnail for this path is not consulted.
+            return []
+        return [{}]
+
+    def handle_file(self, path):
+        ext = extract_path_ext(path)
+        with self.write_file(file_formats.PNG) as fh:
+            if ext == file_formats.PDF:
+                create_image_from_pdf_page(path, fh.name, max_width=1000)
+            elif ext == file_formats.EPUB:
+                create_image_from_epub(path, fh.name)
+            elif ext in (file_formats.HTML5, file_formats.HTML5_ARTICLE):
+                create_image_from_zip(path, fh.name)
+            else:
+                extract_thumbnail_from_video(path, fh.name, overwrite=True)
+        return FileMetadata(preset=THUMBNAIL_PRESETS[ext])
+
+
+class ThumbnailStageHandler(StageHandler):
+    STAGE = "THUMBNAIL"
+    DEFAULT_CHILDREN = [ThumbnailExtractionHandler]
+
+    def execute(
+        self,
+        path: str,
+        context: Optional[Dict] = None,
+        skip_cache: Optional[bool] = False,
+    ) -> list[FileMetadata]:
+        """
+        Pass the source file through unchanged, plus the extracted
+        thumbnail if generation succeeded.
+        """
+        try:
+            thumbnails = super().execute(path, context=context, skip_cache=skip_cache)
+        except (ExpectedFileException, InvalidFileException) as e:
+            # InvalidFileException covers an extractor that completes without
+            # writing any bytes; a failed thumbnail must never fail the node.
+            config.LOGGER.warning(f"\tFailed to extract thumbnail from {path}: {e}")
+            thumbnails = []
+        return [FileMetadata(path=path)] + thumbnails

--- a/tests/media_utils/test_thumbnails.py
+++ b/tests/media_utils/test_thumbnails.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import PIL
 import pytest
@@ -75,6 +76,44 @@ class Test_pdf_thumbnail_generation(BaseThumbnailGeneratorTestCase):
         output_file = tmpdir.join("pdf_16_9.png").strpath
         images.create_image_from_pdf_page(input_file, output_file, crop="smart")
         self.check_16_9_format(output_file)
+
+    def _render_mocked_page(self, tmpdir, native_width_px=None, **kwargs):
+        output_file = tmpdir.join("thumbnail.png").strpath
+        page = PIL.Image.new("RGB", (160, 90))
+        with patch(
+            "ricecooker.utils.images.convert_from_path", return_value=[page]
+        ) as mock_convert:
+            with patch(
+                "ricecooker.utils.images._pdf_page_width_px",
+                return_value=native_width_px,
+            ):
+                images.create_image_from_pdf_page("fake.pdf", output_file, **kwargs)
+        assert os.path.exists(output_file)
+        return mock_convert.call_args.kwargs
+
+    def test_max_width_caps_oversized_page(self, tmpdir):
+        kwargs = self._render_mocked_page(tmpdir, native_width_px=4250, max_width=1000)
+        assert kwargs["size"] == (1000, None)
+
+    def test_max_width_does_not_upscale_small_page(self, tmpdir):
+        kwargs = self._render_mocked_page(tmpdir, native_width_px=600, max_width=1000)
+        assert kwargs["size"] is None
+
+    def test_max_width_applied_when_page_size_unreadable(self, tmpdir):
+        kwargs = self._render_mocked_page(tmpdir, native_width_px=None, max_width=1000)
+        assert kwargs["size"] == (1000, None)
+
+    def test_no_max_width_renders_at_full_size(self, tmpdir):
+        kwargs = self._render_mocked_page(tmpdir)
+        assert kwargs["size"] is None
+
+    def test_pdf_page_width_px_reads_real_pdf(self):
+        input_file = os.path.join(files_dir, "generate_thumbnail", "sample.pdf")
+        width = images._pdf_page_width_px(input_file, page_number=0, dpi=500)
+        assert width is not None and width > 0
+
+    def test_pdf_page_width_px_returns_none_for_unreadable(self):
+        assert images._pdf_page_width_px("fake.pdf", page_number=0, dpi=500) is None
 
     def test_raises_for_missing_file(self, tmpdir):
         input_file = os.path.join(files_dir, "file_that_does_not_exist.pdf")

--- a/tests/pipeline/test_file_handler.py
+++ b/tests/pipeline/test_file_handler.py
@@ -17,23 +17,28 @@ class TestFileHandler(FileHandler):
         return None
 
 
-def test_write_file_with_exception_still_checks_file_not_empty():
+def test_write_file_exception_propagates_unchanged():
     """
-    Test that file_not_empty check runs even when an exception is caught
-    within the context manager. This verifies the try/finally behavior.
-
-    Without the try/finally block, this test would fail because the exception
-    would prevent the file_not_empty check from running.
+    An exception raised inside the write_file body must propagate unchanged -
+    not be masked by the empty-file check - and nothing is copied to storage.
+    This lets handlers raise their typed exceptions (caught via
+    HANDLED_EXCEPTIONS) while writing directly into write_file's temp path.
     """
     handler = TestFileHandler()
 
-    # This should raise InvalidFileException from the finally block,
-    # not the RuntimeError from the try block
+    with pytest.raises(RuntimeError, match="boom"):
+        with handler.write_file("txt"):
+            raise RuntimeError("boom")
+    assert handler._output_path is None, "no partial file should reach storage"
+
+
+def test_write_file_empty_file_raises():
+    """A body that completes without writing anything is treated as corrupt."""
+    handler = TestFileHandler()
+
     with pytest.raises(InvalidFileException, match="failed to write \\(corrupted\\)"):
         with handler.write_file("txt"):
-            # Don't write anything to file (will make it empty)
-            # Then raise an exception that would normally prevent cleanup
-            raise RuntimeError("This exception should be caught by try/finally")
+            pass
 
 
 class ThreadRaceTestHandler(FileHandler):

--- a/tests/pipeline/test_thumbnails.py
+++ b/tests/pipeline/test_thumbnails.py
@@ -1,0 +1,136 @@
+"""Tests for the thumbnail extraction pipeline stage."""
+
+import os
+import shutil
+import tempfile
+from unittest.mock import patch
+
+from le_utils.constants import format_presets
+
+from ricecooker.utils.pipeline.context import NODE_HAS_THUMBNAIL
+from ricecooker.utils.pipeline.thumbnails import ThumbnailStageHandler
+
+
+def _assert_source_and_thumbnail(results, source_path, expected_preset):
+    assert len(results) == 2, "expected source pass-through plus thumbnail"
+    source, thumb = results
+    assert source.path == source_path
+    assert thumb.preset == expected_preset
+    assert thumb.path.endswith(".png")
+    assert os.path.getsize(thumb.path) > 0
+
+
+def test_generates_thumbnail_from_pdf(document_file):
+    results = ThumbnailStageHandler().execute(document_file.path, skip_cache=True)
+    _assert_source_and_thumbnail(
+        results, document_file.path, format_presets.DOCUMENT_THUMBNAIL
+    )
+
+
+def test_generates_thumbnail_from_epub(epub_file):
+    results = ThumbnailStageHandler().execute(epub_file.path, skip_cache=True)
+    _assert_source_and_thumbnail(
+        results, epub_file.path, format_presets.DOCUMENT_THUMBNAIL
+    )
+
+
+def test_generates_thumbnail_from_html_zip(html_file):
+    results = ThumbnailStageHandler().execute(html_file.path, skip_cache=True)
+    _assert_source_and_thumbnail(
+        results, html_file.path, format_presets.HTML5_THUMBNAIL
+    )
+
+
+def test_generates_thumbnail_from_mp4(video_file):
+    # webm is also a supported extension but shares the
+    # extract_thumbnail_from_video code path with mp4; no webm fixture
+    # exists, so mp4 covers the video path.
+    results = ThumbnailStageHandler().execute(video_file.path, skip_cache=True)
+    _assert_source_and_thumbnail(
+        results, video_file.path, format_presets.VIDEO_THUMBNAIL
+    )
+
+
+def test_generates_thumbnail_from_kpub(html_file):
+    # kpub (HTML5_ARTICLE) zips share the zip extraction path with html5,
+    # but map to the document thumbnail preset.
+    tempdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tempdir, "test.kpub")
+        shutil.copy(html_file.path, path)
+        results = ThumbnailStageHandler().execute(path, skip_cache=True)
+        _assert_source_and_thumbnail(results, path, format_presets.DOCUMENT_THUMBNAIL)
+    finally:
+        shutil.rmtree(tempdir)
+
+
+def test_unsupported_format_passes_through(audio_file):
+    results = ThumbnailStageHandler().execute(audio_file.path, skip_cache=True)
+    assert len(results) == 1
+    assert results[0].path == audio_file.path
+
+
+def test_invalid_pdf_passes_source_through(invalid_document_file):
+    results = ThumbnailStageHandler().execute(
+        invalid_document_file.path, skip_cache=True
+    )
+    assert len(results) == 1
+    assert results[0].path == invalid_document_file.path
+
+
+def test_empty_thumbnail_output_passes_source_through(document_file):
+    # An extractor that completes without writing any bytes triggers
+    # write_file's InvalidFileException; the stage treats it as best-effort
+    # and passes the source through rather than failing the node.
+    with patch(
+        "ricecooker.utils.pipeline.thumbnails.create_image_from_pdf_page"
+    ) as mock_create:
+        results = ThumbnailStageHandler().execute(document_file.path, skip_cache=True)
+    assert mock_create.called
+    assert len(results) == 1
+    assert results[0].path == document_file.path
+
+
+def test_skips_generation_when_node_has_thumbnail(document_file):
+    with patch(
+        "ricecooker.utils.pipeline.thumbnails.create_image_from_pdf_page"
+    ) as mock_create:
+        results = ThumbnailStageHandler().execute(
+            document_file.path,
+            context={NODE_HAS_THUMBNAIL: True},
+            skip_cache=True,
+        )
+    # The length check below is the real guard: when generation is skipped,
+    # handle_file is never invoked, so the mock can never be reached.
+    assert not mock_create.called
+    assert len(results) == 1
+    assert results[0].path == document_file.path
+
+
+def test_generates_when_node_has_thumbnail_is_false(document_file):
+    results = ThumbnailStageHandler().execute(
+        document_file.path,
+        context={NODE_HAS_THUMBNAIL: False},
+        skip_cache=True,
+    )
+    assert len(results) == 2
+    assert results[1].preset == format_presets.DOCUMENT_THUMBNAIL
+
+
+def test_thumbnail_cached_on_second_run(document_file):
+    # Copy to a unique path so this test never collides with cache entries
+    # written by other tests or earlier runs.
+    tempdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tempdir, "cached_thumbnail_test.pdf")
+        shutil.copy(document_file.path, path)
+        stage = ThumbnailStageHandler()
+        first = stage.execute(path, skip_cache=True)
+        with patch(
+            "ricecooker.utils.pipeline.thumbnails.create_image_from_pdf_page"
+        ) as mock_create:
+            second = stage.execute(path)
+        assert not mock_create.called, "second run should be served from cache"
+        assert second[1].filename == first[1].filename
+    finally:
+        shutil.rmtree(tempdir)

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -17,7 +17,6 @@ def cli_args_and_expected():
         "warn": False,
         "quiet": False,
         "compress": False,
-        "thumbnails": False,
         "download_attempts": 3,
         "resume": False,
         "step": "LAST",
@@ -25,6 +24,7 @@ def cli_args_and_expected():
         "reset_deprecated": False,
         "stage": True,
         "stage_deprecated": False,
+        "thumbnails_deprecated": False,
         "publish": False,
         "sample": None,
     }
@@ -37,6 +37,14 @@ def cli_args_and_expected():
         {  # nowadays we've changed the CLI defaults so don't need to specify these
             "cli_input": "./sushichef.py --token=letoken",
             "expected_args": dict(defaults, token="letoken"),
+            "expected_options": {},
+        },
+        {  # --thumbnails is deprecated (generation is always on) but must
+            # still parse as a no-op rather than crash options parsing
+            "cli_input": "./sushichef.py --token=letoken --thumbnails",
+            "expected_args": dict(
+                defaults, token="letoken", thumbnails_deprecated=True
+            ),
             "expected_options": {},
         },
         {

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1379,6 +1379,8 @@ def test_html5_zip_cache_keys(mock_filecache, html_file):
     html = HTMLZipFile(path)
     html.process_file()
 
+    # No THUMBNAIL key: the legacy DownloadFile path skips the pipeline
+    # thumbnail stage (node-level generation handles legacy thumbnails).
     expected_keys = {
         f"DOWNLOAD:{path}",
         f"CONVERT:{html.filename}",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,7 +9,7 @@ from ricecooker import chefs
 from ricecooker.utils.request_utils import DomainSpecificAuth
 
 
-settings = {"thumbnails": True, "compress": True}
+settings = {"compress": True}
 
 
 def test_settings_unset_default():
@@ -36,32 +36,27 @@ def test_cli_args_override_settings():
     takes precedence over the default setting.
     """
 
-    test_argv = ["sushichef.py", "--compress", "--thumbnails", "--token", "12345"]
+    test_argv = ["sushichef.py", "--compress", "--token", "12345"]
 
     with patch.object(sys, "argv", test_argv):
         chef = chefs.SushiChef()
-        chef.SETTINGS["thumbnails"] = False
         chef.SETTINGS["compress"] = False
 
-        assert chef.get_setting("thumbnails") is False
         assert chef.get_setting("compress") is False
 
         chef.parse_args_and_options()
-        assert chef.get_setting("thumbnails") is True
         assert chef.get_setting("compress") is True
 
-    test_argv = ["sushichef.py", "--compress", "--thumbnails", "--token", "12345"]
+    test_argv = ["sushichef.py", "--compress", "--token", "12345"]
 
     with patch.object(sys, "argv", test_argv):
         chef = chefs.SushiChef()
 
         assert len(chef.SETTINGS) == 0
 
-        assert chef.get_setting("thumbnails") is None
         assert chef.get_setting("compress") is None
 
         chef.parse_args_and_options()
-        assert chef.get_setting("thumbnails") is True
         assert chef.get_setting("compress") is True
 
     # now test without setting the flags
@@ -69,15 +64,26 @@ def test_cli_args_override_settings():
 
     with patch.object(sys, "argv", test_argv):
         chef = chefs.SushiChef()
-        chef.SETTINGS["thumbnails"] = False
         chef.SETTINGS["compress"] = False
 
-        assert chef.get_setting("thumbnails") is False
         assert chef.get_setting("compress") is False
 
         chef.parse_args_and_options()
-        assert chef.get_setting("thumbnails") is False
         assert chef.get_setting("compress") is False
+
+
+def test_deprecated_thumbnail_settings_warn():
+    """
+    Thumbnail generation is always on, so the old opt-in SETTINGS keys are
+    obsolete; instantiation must warn rather than silently ignore them.
+    """
+    for key in ("thumbnails", "generate-missing-thumbnails"):
+
+        class ThumbnailSettingsChef(chefs.SushiChef):
+            SETTINGS = {key: True}
+
+        with pytest.warns(DeprecationWarning, match=key):
+            ThumbnailSettingsChef()
 
 
 # Domain-specific authentication tests

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -1,7 +1,10 @@
 import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import PIL
 import pytest  # noqa F401
+from le_utils.constants import format_presets
 from le_utils.constants import licenses
 from test_tree import thumbnail_path  # noqa F401
 from test_tree import thumbnail_path_jpg  # noqa F401
@@ -13,13 +16,18 @@ from ricecooker.classes.files import ExtractedEPubThumbnailFile
 from ricecooker.classes.files import ExtractedHTMLZipThumbnailFile
 from ricecooker.classes.files import ExtractedPdfThumbnailFile
 from ricecooker.classes.files import ExtractedVideoThumbnailFile
+from ricecooker.classes.files import File
 from ricecooker.classes.files import ThumbnailFile
 from ricecooker.classes.files import TiledThumbnailFile
 from ricecooker.classes.files import VideoFile
+from ricecooker.classes.nodes import ContentNode
 from ricecooker.classes.nodes import DocumentNode
 from ricecooker.classes.nodes import HTML5AppNode
 from ricecooker.classes.nodes import TopicNode
 from ricecooker.classes.nodes import VideoNode
+from ricecooker.managers.tree import ChannelManager
+from ricecooker.utils.images import ThumbnailGenerationError
+from ricecooker.utils.pipeline.context import NODE_HAS_THUMBNAIL
 
 
 SHOW_THUMBS = False  # set to True to show outputs when running tests locally
@@ -163,6 +171,134 @@ class TestThumbnailSetting(object):
         self.assert_failed_thumbnail(video_node)
 
 
+class TestIsThumbnail(object):
+    """File.is_thumbnail() detects thumbnails by format preset, not class."""
+
+    def test_plain_file_with_thumbnail_preset(self):
+        f = File(preset=format_presets.DOCUMENT_THUMBNAIL, filename="abc.png")
+        assert f.is_thumbnail() is True
+
+    def test_plain_file_with_content_preset(self):
+        f = File(preset=format_presets.DOCUMENT, filename="abc.pdf")
+        assert f.is_thumbnail() is False
+
+    def test_plain_file_without_preset(self):
+        f = File(filename="abc.pdf")
+        assert f.is_thumbnail() is False
+
+    def test_thumbnail_file_attached_to_node(self, thumbnail_path):  # noqa F811
+        node = DocumentNode(
+            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=thumbnail_path
+        )
+        assert any(f.is_thumbnail() for f in node.files)
+
+    def test_unattached_thumbnail_file_is_not_thumbnail(
+        self,
+        thumbnail_path,  # noqa F811
+    ):
+        # A ThumbnailFile with no node cannot resolve its preset.
+        f = ThumbnailFile(thumbnail_path)
+        assert f.is_thumbnail() is False
+
+    def test_thumbnail_file_on_kindless_node_is_not_thumbnail(
+        self,
+        thumbnail_path,  # noqa F811
+    ):
+        # Attached to a node that has no kind yet (a uri-based node before
+        # the pipeline has run), so the preset is unresolvable.
+        node = ContentNode(
+            "src-id", "Title", licenses.PUBLIC_DOMAIN, uri="/tmp/doc.pdf"
+        )
+        f = ThumbnailFile(thumbnail_path)
+        node.add_file(f)
+        assert f.is_thumbnail() is False
+
+
+class TestHasThumbnail(object):
+    """Node.has_thumbnail() detects provided and preset-based thumbnails."""
+
+    def test_pipeline_generated_thumbnail_counts(self):
+        node = DocumentNode("doc-src-id", "Document", licenses.PUBLIC_DOMAIN)
+        node.add_file(
+            File(preset=format_presets.DOCUMENT_THUMBNAIL, filename="abc.png")
+        )
+        assert node.has_thumbnail() is True
+
+    def test_content_file_does_not_count(self):
+        node = DocumentNode("doc-src-id", "Document", licenses.PUBLIC_DOMAIN)
+        node.add_file(File(preset=format_presets.DOCUMENT, filename="abc.pdf"))
+        assert node.has_thumbnail() is False
+
+    def test_provided_thumbnail_counts_before_kind_is_known(
+        self,
+        thumbnail_path,  # noqa F811
+    ):
+        # uri-based ContentNode has no kind until the pipeline has run, so the
+        # ThumbnailFile preset is unresolvable - self.thumbnail must count.
+        node = ContentNode(
+            "src-id",
+            "Title",
+            licenses.PUBLIC_DOMAIN,
+            uri="/tmp/does-not-matter.pdf",
+            thumbnail=thumbnail_path,
+        )
+        assert node.has_thumbnail() is True
+
+    def test_process_uri_passes_node_has_thumbnail_context(
+        self,
+        thumbnail_path,  # noqa F811
+    ):
+        pipeline = MagicMock()
+        pipeline.execute.return_value = []
+
+        node = ContentNode(
+            "src-id",
+            "Title",
+            licenses.PUBLIC_DOMAIN,
+            uri="/tmp/doc.pdf",
+            pipeline=pipeline,
+        )
+        node._process_uri()
+        pipeline.execute.assert_called_once_with(
+            "/tmp/doc.pdf",
+            context={NODE_HAS_THUMBNAIL: False},
+            skip_cache=config.UPDATE,
+        )
+
+        pipeline.reset_mock()
+        node.set_thumbnail(thumbnail_path)
+        node._process_uri()
+        pipeline.execute.assert_called_once_with(
+            "/tmp/doc.pdf",
+            context={NODE_HAS_THUMBNAIL: True},
+            skip_cache=config.UPDATE,
+        )
+
+    def test_process_uri_counts_thumbnail_file_passed_in_files(
+        self,
+        thumbnail_path,  # noqa F811
+    ):
+        # A ThumbnailFile in files=[...] cannot resolve its preset before the
+        # node has a kind, but it must still suppress pipeline generation.
+        pipeline = MagicMock()
+        pipeline.execute.return_value = []
+
+        node = ContentNode(
+            "src-id",
+            "Title",
+            licenses.PUBLIC_DOMAIN,
+            uri="/tmp/doc.pdf",
+            pipeline=pipeline,
+            files=[ThumbnailFile(thumbnail_path)],
+        )
+        node._process_uri()
+        pipeline.execute.assert_called_once_with(
+            "/tmp/doc.pdf",
+            context={NODE_HAS_THUMBNAIL: True},
+            skip_cache=config.UPDATE,
+        )
+
+
 class TestThumbnailGeneration(object):
     def setup_method(self, test_method):
         """
@@ -170,7 +306,6 @@ class TestThumbnailGeneration(object):
         """
         _clear_ricecookerfilecache()
         config.FAILED_FILES = []
-        config.THUMBNAILS = False
 
     def check_has_thumbnail(self, node):
         thumbnail_files = [
@@ -212,7 +347,6 @@ class TestThumbnailGeneration(object):
             "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
         )
         node.add_file(document_file)
-        config.THUMBNAILS = True
         filenames = node.process_files()
         assert len(filenames) == 2, "expected two filenames"
         self.check_has_thumbnail(node)
@@ -222,7 +356,6 @@ class TestThumbnailGeneration(object):
             "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=None
         )
         node.add_file(epub_file)
-        config.THUMBNAILS = True
         filenames = node.process_files()
         assert len(filenames) == 2, "expected two filenames"
         self.check_has_thumbnail(node)
@@ -232,7 +365,6 @@ class TestThumbnailGeneration(object):
             "html-src-id", "HTML5 App", licenses.PUBLIC_DOMAIN, thumbnail=None
         )
         node.add_file(html_file)
-        config.THUMBNAILS = True
         filenames = node.process_files()
         assert len(filenames) == 2, "expected two filenames"
         self.check_has_thumbnail(node)
@@ -240,23 +372,44 @@ class TestThumbnailGeneration(object):
     def test_generate_thumbnail_from_video(self, video_file):
         node = VideoNode("vid-src-id", "Video", licenses.PUBLIC_DOMAIN, thumbnail=None)
         node.add_file(video_file)
-        config.THUMBNAILS = True
         filenames = node.process_files()
         assert len(filenames) == 2, "expected two filenames"
         self.check_has_thumbnail(node)
 
-    def test_generate_tiled_thumbnail(self, document, html, video, audio):
+    def test_topic_does_not_generate_thumbnail_in_process_files(
+        self, document, html, video, audio
+    ):
         topic = TopicNode("test-topic", "Topic")
-        topic.add_child(document)
-        topic.add_child(html)
-        topic.add_child(video)
-        topic.add_child(audio)
-        config.THUMBNAILS = True
-        for child in topic.children:  # must process children before topic node
+        # Children are processed first so their thumbnails would be available;
+        # the topic must still defer (the tree manager post-pass tiles later).
+        for child in (document, html, video, audio):
+            topic.add_child(child)
             child.process_files()
         filenames = topic.process_files()
-        assert len(filenames) == 1, "expected one filename"
-        self.check_has_thumbnail(topic)
+        assert filenames == [], "topic thumbnail generation must be deferred"
+        assert not topic.has_thumbnail()
+
+    def test_legacy_file_processing_skips_pipeline_thumbnail_stage(self, document_file):
+        # The legacy DownloadFile path only consumes the source metadata, so
+        # the pipeline thumbnail stage must not generate an image for it
+        # (node-level generate_missing_thumbnail handles legacy thumbnails).
+        with patch(
+            "ricecooker.utils.pipeline.thumbnails.create_image_from_pdf_page"
+        ) as mock_create:
+            filename = document_file.process_file()
+        assert filename is not None
+        assert not mock_create.called
+
+    def test_generate_missing_thumbnail_noop_when_thumbnail_present(
+        self,
+        document_file,
+        thumbnail_path,  # noqa F811
+    ):
+        node = DocumentNode(
+            "doc-src-id", "Document", licenses.PUBLIC_DOMAIN, thumbnail=thumbnail_path
+        )
+        node.add_file(document_file)
+        assert node.generate_missing_thumbnail() == []
 
     # ERROR PATHS
     ############################################################################
@@ -328,3 +481,109 @@ class TestThumbnailGeneration(object):
         assert result is None, "expected None result for invalid MP4"
         assert len(config.FAILED_FILES) == 1, "expected one failed file"
         assert thumbnail_file.filename is None, "filename should remain None"
+
+
+class TestDeferredTopicThumbnails(object):
+    def setup_method(self, test_method):
+        _clear_ricecookerfilecache()
+        config.FAILED_FILES = []
+
+    def _content_node(self, cls, source_id, file_obj):
+        node = cls(source_id, source_id, licenses.PUBLIC_DOMAIN)
+        node.add_file(file_obj)
+        return node
+
+    def _build_topic(self, channel, children, thumbnail=None):
+        topic = TopicNode("test-topic", "Topic", thumbnail=thumbnail)
+        channel.add_child(topic)
+        for child in children:
+            topic.add_child(child)
+        return topic
+
+    def test_topic_gets_tiled_thumbnail_via_post_pass(
+        self, channel, document_file, html_file, video_file
+    ):
+        children = [
+            self._content_node(DocumentNode, "doc-src-id", document_file),
+            self._content_node(HTML5AppNode, "html-src-id", html_file),
+            self._content_node(VideoNode, "vid-src-id", video_file),
+        ]
+        topic = self._build_topic(channel, children)
+
+        manager = ChannelManager(channel)
+        filenames = manager.process_tree()
+
+        assert topic.has_thumbnail(), "topic should have a generated tile"
+        tile_files = [f for f in topic.files if f.is_thumbnail()]
+        assert len(tile_files) == 1
+        tile_filename = tile_files[0].get_filename()
+        assert tile_filename in filenames, "tile must be registered for upload"
+        assert os.path.exists(config.get_storage_path(tile_filename))
+
+    def test_topic_with_provided_thumbnail_is_untouched(
+        self,
+        channel,
+        document_file,
+        thumbnail_path,  # noqa F811
+    ):
+        children = [self._content_node(DocumentNode, "doc-src-id", document_file)]
+        topic = self._build_topic(channel, children, thumbnail=thumbnail_path)
+
+        manager = ChannelManager(channel)
+        manager.process_tree()
+
+        thumb_files = [f for f in topic.files if f.is_thumbnail()]
+        assert len(thumb_files) == 1, "no second thumbnail should be generated"
+        assert isinstance(thumb_files[0], ThumbnailFile)
+        assert not isinstance(thumb_files[0], TiledThumbnailFile)
+
+    def test_tile_sources_include_generated_child_thumbnails(
+        self, channel, document_file
+    ):
+        # The child has no provided thumbnail: it generates its own during
+        # process_files, and the topic tile is built from that generated
+        # thumbnail afterward.
+        children = [self._content_node(DocumentNode, "doc-src-id", document_file)]
+        topic = self._build_topic(channel, children)
+
+        manager = ChannelManager(channel)
+        manager.process_tree()
+        assert topic.has_thumbnail()
+
+    def test_topic_with_no_eligible_descendants_stays_thumbnail_less(self, channel):
+        topic = self._build_topic(channel, [])
+
+        manager = ChannelManager(channel)
+        filenames = manager.process_tree()
+
+        assert not topic.has_thumbnail()
+        assert filenames == []
+
+    def test_failed_tile_generation_is_recorded(
+        self,
+        channel,
+        document_file,
+        monkeypatch,
+    ):
+        children = [self._content_node(DocumentNode, "doc-src-id", document_file)]
+        topic = self._build_topic(channel, children)
+
+        def boom(*args, **kwargs):
+            raise ThumbnailGenerationError("tile failure")
+
+        monkeypatch.setattr("ricecooker.classes.files.create_tiled_image", boom)
+        manager = ChannelManager(channel)
+        manager.process_tree()
+
+        assert not topic.has_thumbnail()
+        failed = [f for f in config.FAILED_FILES if isinstance(f, TiledThumbnailFile)]
+        assert len(failed) == 1
+        assert failed[0].error == "tile failure"
+
+    def test_tile_sources_skip_unprocessed_thumbnails(self):
+        # A thumbnail file that failed to process (filename is None) must be
+        # skipped as a tile source, not re-processed by the tile build.
+        node = DocumentNode("doc-src-id", "Document", licenses.PUBLIC_DOMAIN)
+        node.add_file(File(preset=format_presets.DOCUMENT_THUMBNAIL, filename=None))
+        tiled = TiledThumbnailFile([node])
+        assert tiled.sources == []


### PR DESCRIPTION
## Summary

Thumbnails are now always generated for content nodes and topics that don't provide one. Generation is cached and low-cost, so it is no longer opt-in.

**Breaking change:** the `config.THUMBNAILS` gate, `--thumbnails` CLI flag, `generate-missing-thumbnails` settings shim, and `derive_thumbnail` node kwarg are removed. Chefs passing `derive_thumbnail` will get a `TypeError`.

Topic tiles are generated in a sequential post-pass after tree processing, fixing a latent race where the thread-pool executor could process a topic before its children's thumbnails existed.

## References

Related (not fixed): #490 — topics whose children are `StudioContentNode`s still get no tile, since their thumbnails exist only on Studio.

## Reviewer guidance

Test coverage: `tests/pipeline/test_thumbnails.py` (new pipeline stage) and `tests/test_thumbnails.py` (node-level generation + deferred topic tiles). For an end-to-end check, run any chef with no flags — content nodes get generated thumbnails and topics get tiles; pass `thumbnail=...` on a node and confirm it wins over generation.

Areas deserving extra attention:
- `ricecooker/utils/pipeline/file_handler.py:136` — `write_file` no longer runs the empty-file check and storage copy when the body raises; this is framework-wide (all transfer/convert/thumbnail handlers). All 11 call sites were checked against the new semantics, but it has the widest blast radius in the PR.
- `ricecooker/managers/tree.py:114` — the deferred-thumbnail post-pass relies on `all_nodes` being children-first, runs sequentially after the concurrent executor, and registers tile files into `file_map` for upload.
- `ricecooker/classes/nodes.py:266` — `has_thumbnail()` is now preset-based plus an explicit `self.thumbnail` check; this changes thumbnail-detection semantics for legacy `File` classes too (`classes/files.py:105`).

## AI usage

This PR was built with Claude Code: the design spec and implementation plan were drafted collaboratively and human-reviewed, implementation ran task-by-task from the plan (tests written first), and the diff went through three AI-assisted review rounds with fixes before commit. I reviewed the spec, plan, and diff at each checkpoint and verified the full test suite and lint locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)